### PR TITLE
[Local Skip Graph] Generic Identity

### DIFF
--- a/src/core/lookup/lookup_table.rs
+++ b/src/core/lookup/lookup_table.rs
@@ -5,11 +5,11 @@ use crate::core::model::identity::Identity;
 pub type Level = usize;
 
 /// LookupTable is the core view of Skip Graph node towards the network.
-pub trait LookupTable {
+pub trait LookupTable<T> {
     /// Update the entry at the given level and direction.
     fn update_entry(
         &mut self,
-        identity: Identity,
+        identity: Identity<T>,
         level: Level,
         direction: Direction,
     ) -> anyhow::Result<()>;
@@ -20,5 +20,5 @@ pub trait LookupTable {
     /// Get the entry at the given level and direction.
     /// Returns None if the entry is not present.
     /// Returns Some(Identity) if the entry is present.
-    fn get_entry(&self, level: Level, direction: Direction) -> anyhow::Result<Option<&Identity>>;
+    fn get_entry(&self, level: Level, direction: Direction) -> anyhow::Result<Option<&Identity<T>>>;
 }

--- a/src/core/model/identity.rs
+++ b/src/core/model/identity.rs
@@ -1,20 +1,21 @@
+use crate::add;
 use crate::core::{Address, Identifier, MembershipVector};
 
 /// Identity is an immutable struct that represents a node's identity in the network (ID, MembershipVector, Address).
 #[derive(Clone, Copy, Debug, PartialEq)]
-pub struct Identity {
+pub struct Identity<T> {
     id: Identifier,
     mem_vec: MembershipVector,
-    address: Address,
+    address: T,
 }
 
-impl Identity {
+impl<T> Identity<T> where {
     /// Create a new Identity
-    pub fn new(id: &Identifier, mem_vec: &MembershipVector, address: &Address) -> Identity {
+    pub fn new(id: &Identifier, mem_vec: &MembershipVector, address: T) -> Identity<T> {
         Identity {
             id: id.clone(),
             mem_vec: mem_vec.clone(),
-            address: address.clone(),
+            address,
         }
     }
 
@@ -29,7 +30,7 @@ impl Identity {
     }
 
     /// Get the address of the node
-    pub fn address(&self) -> &Address {
+    pub fn address(&self) -> T {
         &self.address
     }
 }

--- a/src/core/model/identity.rs
+++ b/src/core/model/identity.rs
@@ -1,4 +1,3 @@
-use crate::add;
 use crate::core::{Address, Identifier, MembershipVector};
 
 /// Identity is an immutable struct that represents a node's identity in the network (ID, MembershipVector, Address).
@@ -9,7 +8,7 @@ pub struct Identity<T> {
     address: T,
 }
 
-impl<T> Identity<T> where {
+impl<T> Identity<T> where T : Copy {
     /// Create a new Identity
     pub fn new(id: &Identifier, mem_vec: &MembershipVector, address: T) -> Identity<T> {
         Identity {
@@ -31,7 +30,7 @@ impl<T> Identity<T> where {
 
     /// Get the address of the node
     pub fn address(&self) -> T {
-        &self.address
+        self.address
     }
 }
 

--- a/src/core/search/id_search_res.rs
+++ b/src/core/search/id_search_res.rs
@@ -1,7 +1,7 @@
 use crate::core::model::identity::Identity;
 use crate::core::search::id_search_req::IdentifierSearchRequest;
 
-pub struct IdentifierSearchResult {
+pub struct IdentifierSearchResult<T> {
     pub req : IdentifierSearchRequest,
-    pub result: Option<Identity>,    
+    pub result: Option<Identity<T>>,
 }

--- a/src/core/search/identifier_searcher.rs
+++ b/src/core/search/identifier_searcher.rs
@@ -3,13 +3,13 @@ use crate::core::lookup::lookup_table::LookupTable;
 use crate::core::search::id_search_req::IdentifierSearchRequest;
 use crate::core::search::id_search_res::IdentifierSearchResult;
 
-trait IdentifierSearcher {
+trait IdentifierSearcher<T> {
     /// Performs the search for given identifier in the lookup table in the given direction and level.
     /// Essentially looks for the first match in the direction for the given level and all levels below.
     /// The match is the first entry that is greater than or equal to the target identifier (for left direction), 
     /// or less than or equal to the target identifier (for right direction).
     /// Returns the search result.
     /// If the lookup table is empty in that direction, returns None.
-    fn search_by_id(&self, lookup_table: &dyn LookupTable, search_req : IdentifierSearchRequest) -> anyhow::Result<IdentifierSearchResult>;
+    fn search_by_id(&self, lookup_table: &dyn LookupTable<T>, search_req : IdentifierSearchRequest) -> anyhow::Result<IdentifierSearchResult<T>>;
 }
 

--- a/src/core/testutil/fixtures.rs
+++ b/src/core/testutil/fixtures.rs
@@ -32,18 +32,18 @@ pub fn random_address() -> Address {
     Address::new("localhost", &random_port().to_string())
 }
 
-/// Generate a random identity
-pub fn random_identity() -> Identity {
+/// Generate a random network identity; ID, MembershipVector, Address.
+pub fn random_network_identity() -> Identity<Address> {
     Identity::new(
         &random_identifier(),
         &random_membership_vector(),
-        &random_address(),
+        random_address(),
     )
 }
 
-/// Generate n random identities
-pub fn random_identities(n: usize) -> Vec<Identity> {
-    (0..n).map(|_| random_identity()).collect()
+/// Generate n random network identities; ID, MembershipVector, Address.
+pub fn random_network_identities(n: usize) -> Vec<Identity<Address>> {
+    (0..n).map(|_| random_network_identity()).collect()
 }
 
 #[cfg(test)]
@@ -56,7 +56,7 @@ mod test {
         let ids = super::random_sorted_identifiers(100);
 
         // ensures that the identifiers are sorted in ascending order
-        ids.iter().skip(1).fold(&ids[0], |prev, curr|  {
+        ids.iter().skip(1).fold(&ids[0], |prev, curr| {
             assert_eq!(CompareLess, prev.compare(curr).result());
             curr
         });


### PR DESCRIPTION
Addresses https://github.com/thep2p/skip-graphs/issues/2

This pull request introduces generics to the `ArrayLookupTable` and related structures and traits to improve flexibility and reusability. Additionally, it updates the test cases to reflect these changes.

Changes to generics:

* [`src/core/lookup/array_lookup_table.rs`](diffhunk://#diff-19dbb7f9cc445561c37ef0274d9b24a658f6d8fce02907101f3b6e8eb2446a17L9-R28): Modified `ArrayLookupTable` to be a generic struct and updated its methods to use the generic type `T`. [[1]](diffhunk://#diff-19dbb7f9cc445561c37ef0274d9b24a658f6d8fce02907101f3b6e8eb2446a17L9-R28) [[2]](diffhunk://#diff-19dbb7f9cc445561c37ef0274d9b24a658f6d8fce02907101f3b6e8eb2446a17L80-R80) [[3]](diffhunk://#diff-19dbb7f9cc445561c37ef0274d9b24a658f6d8fce02907101f3b6e8eb2446a17R97-R104)
* [`src/core/lookup/lookup_table.rs`](diffhunk://#diff-0fc5a8c10a698bcf5b12e78407878e9570afd34cfd60b98ab4975d7b02d71498L8-R12): Updated the `LookupTable` trait to be generic, allowing it to work with `Identity<T>`. [[1]](diffhunk://#diff-0fc5a8c10a698bcf5b12e78407878e9570afd34cfd60b98ab4975d7b02d71498L8-R12) [[2]](diffhunk://#diff-0fc5a8c10a698bcf5b12e78407878e9570afd34cfd60b98ab4975d7b02d71498L23-R23)
* [`src/core/model/identity.rs`](diffhunk://#diff-94752461df5824dc669423f1833828455beafbda0ca9f5ef071f2e31eeeee337L5-R17): Made the `Identity` struct generic and updated its methods to use the generic type `T`. [[1]](diffhunk://#diff-94752461df5824dc669423f1833828455beafbda0ca9f5ef071f2e31eeeee337L5-R17) [[2]](diffhunk://#diff-94752461df5824dc669423f1833828455beafbda0ca9f5ef071f2e31eeeee337L32-R33)
* [`src/core/search/id_search_res.rs`](diffhunk://#diff-f3d6c6e4cf06a937577d6fa4cbe2a3f892fe97b6e64555c37567c2b5439131d2L4-R6): Modified `IdentifierSearchResult` to be a generic struct.
* [`src/core/search/identifier_searcher.rs`](diffhunk://#diff-c6f90f7d017623c5d9b90dc5884e1e30840b00566c97ba420c6b68c2dc9c1685L6-R13): Updated the `IdentifierSearcher` trait to be generic.

Updates to test cases:

* [`src/core/lookup/array_lookup_table.rs`](diffhunk://#diff-19dbb7f9cc445561c37ef0274d9b24a658f6d8fce02907101f3b6e8eb2446a17L116-R118): Updated test cases to use the new generic `ArrayLookupTable` and `Identity` structures. [[1]](diffhunk://#diff-19dbb7f9cc445561c37ef0274d9b24a658f6d8fce02907101f3b6e8eb2446a17L116-R118) [[2]](diffhunk://#diff-19dbb7f9cc445561c37ef0274d9b24a658f6d8fce02907101f3b6e8eb2446a17L133-R135) [[3]](diffhunk://#diff-19dbb7f9cc445561c37ef0274d9b24a658f6d8fce02907101f3b6e8eb2446a17L150-R151) [[4]](diffhunk://#diff-19dbb7f9cc445561c37ef0274d9b24a658f6d8fce02907101f3b6e8eb2446a17L177-R179)
* [`src/core/testutil/fixtures.rs`](diffhunk://#diff-a700e81f90823ba0d251d3ce60358514aaf6ba97b0de4ccd682715899567c724L35-R46): Changed utility functions to generate generic `Identity` instances.