### PR TITLE
[Lint] Enforces lint warnings as errors and fixes the warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ install-lint:
 .PHONEY lint:
 lint:
 	@echo "Running clippy"
-	@cargo clippy
+	@cargo clippy -- -D warnings
 
 .PHONEY install-tools:
 install-tools: install-lint

--- a/src/core/lookup/array_lookup_table.rs
+++ b/src/core/lookup/array_lookup_table.rs
@@ -31,10 +31,9 @@ where
     T: Clone + Debug,
 {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        let mut i = 0;
-        for (l, r) in self.left.iter().zip(self.right.iter()) {
-            write!(f, "Level: {}, Left: {:?}, Right: {:?}\n", i, l, r)?;
-            i += 1;
+
+        for (i, (l, r)) in self.left.iter().zip(self.right.iter()).enumerate() {
+            writeln!(f, "Level: {}, Left: {:?}, Right: {:?}", i, l, r)?;
         }
         Ok(())
     }

--- a/src/core/lookup/array_lookup_table.rs
+++ b/src/core/lookup/array_lookup_table.rs
@@ -26,6 +26,15 @@ where
     }
 }
 
+impl <T> Default for ArrayLookupTable<T>
+where
+    T: Clone,
+{
+    fn default() -> Self {
+        ArrayLookupTable::new()
+    }
+}
+
 impl<T> Debug for ArrayLookupTable<T>
 where
     T: Clone + Debug,

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -1,5 +1,5 @@
 mod lookup;
-mod model;
+pub mod model;
 pub mod testutil;
 mod search;
 mod node;

--- a/src/core/model/address.rs
+++ b/src/core/model/address.rs
@@ -18,12 +18,12 @@ impl Address {
 
     /// Get the host
     pub fn host(&self) -> &str {
-        &self.host.as_str()
+        self.host.as_str()
     }
 
     /// Get the port
     pub fn port(&self) -> &str {
-        &self.port.as_str()
+        self.port.as_str()
     }
 }
 

--- a/src/core/model/identifier.rs
+++ b/src/core/model/identifier.rs
@@ -1,7 +1,7 @@
 use crate::core::model;
 use crate::core::model::identifier::ComparisonResult::{CompareEqual, CompareGreater, CompareLess};
 use crate::core::model::IDENTIFIER_SIZE_BYTES;
-use anyhow::{anyhow, Context};
+use anyhow::{anyhow};
 use std::fmt;
 use std::fmt::{Display, Formatter};
 
@@ -16,7 +16,6 @@ pub enum ComparisonResult {
     CompareEqual,
     CompareLess,
 }
-
 
 /// ComparisonContext represents the context of a comparison between two identifiers.
 /// It contains the result of the comparison, the left and right identifiers, and the index of the differing byte.

--- a/src/core/model/identifier.rs
+++ b/src/core/model/identifier.rs
@@ -79,20 +79,24 @@ pub struct Identifier([u8; model::IDENTIFIER_SIZE_BYTES]);
 impl Identifier {
     pub fn compare(&self, other: &Identifier) -> ComparisonContext {
         for i in 0..model::IDENTIFIER_SIZE_BYTES {
-            if self.0[i] < other.0[i] {
-                return ComparisonContext {
-                    result: CompareLess,
-                    left: *self,
-                    right: *other,
-                    diff_index: i,
-                };
-            } else if self.0[i] > other.0[i] {
-                return ComparisonContext {
-                    result: CompareGreater,
-                    left: *self,
-                    right: *other,
-                    diff_index: i,
-                };
+            match self.0[i].cmp(&other.0[i]) {
+                std::cmp::Ordering::Less => {
+                    return ComparisonContext {
+                        result: CompareLess,
+                        left: *self,
+                        right: *other,
+                        diff_index: i,
+                    };
+                }
+                std::cmp::Ordering::Greater => {
+                    return ComparisonContext {
+                        result: CompareGreater,
+                        left: *self,
+                        right: *other,
+                        diff_index: i,
+                    };
+                }
+                _ => {}
             }
         }
         ComparisonContext {

--- a/src/core/model/identifier.rs
+++ b/src/core/model/identifier.rs
@@ -82,23 +82,23 @@ impl Identifier {
             if self.0[i] < other.0[i] {
                 return ComparisonContext {
                     result: CompareLess,
-                    left: self.clone(),
-                    right: other.clone(),
+                    left: *self,
+                    right: *other,
                     diff_index: i,
                 };
             } else if self.0[i] > other.0[i] {
                 return ComparisonContext {
                     result: CompareGreater,
-                    left: self.clone(),
-                    right: other.clone(),
+                    left: *self,
+                    right: *other,
                     diff_index: i,
                 };
             }
         }
         ComparisonContext {
             result: CompareEqual,
-            left: self.clone(),
-            right: other.clone(),
+            left: *self,
+            right: *other,
             diff_index: IDENTIFIER_SIZE_BYTES,
         }
     }

--- a/src/core/model/identifier.rs
+++ b/src/core/model/identifier.rs
@@ -136,7 +136,7 @@ impl Identifier {
 impl Display for Identifier {
     /// Converts the Identifier into a base hex string.
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", hex::encode(&self.0))
+        write!(f, "{}", hex::encode(self.0))
     }
 }
 

--- a/src/core/model/identity.rs
+++ b/src/core/model/identity.rs
@@ -15,8 +15,8 @@ where
     /// Create a new Identity
     pub fn new(id: &Identifier, mem_vec: &MembershipVector, address: T) -> Identity<T> {
         Identity {
-            id: id.clone(),
-            mem_vec: mem_vec.clone(),
+            id: *id,
+            mem_vec: *mem_vec,
             address,
         }
     }

--- a/src/core/model/identity.rs
+++ b/src/core/model/identity.rs
@@ -1,4 +1,4 @@
-use crate::core::{Address, Identifier, MembershipVector};
+use crate::core::{Identifier, MembershipVector};
 
 /// Identity is an immutable struct that represents a node's identity in the network (ID, MembershipVector, Address).
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -39,6 +39,7 @@ where
 
 #[cfg(test)]
 mod tests {
+    use crate::core::Address;
     use super::*;
     use crate::core::testutil::fixtures::{random_identifier, random_membership_vector};
 

--- a/src/core/model/memvec.rs
+++ b/src/core/model/memvec.rs
@@ -27,7 +27,7 @@ impl MembershipVector {
         } else {
             let mut mv = [0u8; model::IDENTIFIER_SIZE_BYTES];
             let offset = model::IDENTIFIER_SIZE_BYTES - bytes.len();
-            mv[offset..].copy_from_slice(&bytes);
+            mv[offset..].copy_from_slice(bytes);
             Ok(MembershipVector(mv))
         }
     }
@@ -134,7 +134,7 @@ impl MembershipVector {
 
 impl Display for MembershipVector {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", hex::encode(&self.0))
+        write!(f, "{}", hex::encode(self.0))
     }
 }
 

--- a/src/core/search/identifier_searcher.rs
+++ b/src/core/search/identifier_searcher.rs
@@ -1,4 +1,3 @@
-use crate::core::model::identity::Identity;
 use crate::core::lookup::lookup_table::LookupTable;
 use crate::core::search::id_search_req::IdentifierSearchRequest;
 use crate::core::search::id_search_res::IdentifierSearchResult;
@@ -6,10 +5,13 @@ use crate::core::search::id_search_res::IdentifierSearchResult;
 trait IdentifierSearcher<T> {
     /// Performs the search for given identifier in the lookup table in the given direction and level.
     /// Essentially looks for the first match in the direction for the given level and all levels below.
-    /// The match is the first entry that is greater than or equal to the target identifier (for left direction), 
+    /// The match is the first entry that is greater than or equal to the target identifier (for left direction),
     /// or less than or equal to the target identifier (for right direction).
     /// Returns the search result.
     /// If the lookup table is empty in that direction, returns None.
-    fn search_by_id(&self, lookup_table: &dyn LookupTable<T>, search_req : IdentifierSearchRequest) -> anyhow::Result<IdentifierSearchResult<T>>;
+    fn search_by_id(
+        &self,
+        lookup_table: &dyn LookupTable<T>,
+        search_req: IdentifierSearchRequest,
+    ) -> anyhow::Result<IdentifierSearchResult<T>>;
 }
-

--- a/src/core/search/identifier_searcher.rs
+++ b/src/core/search/identifier_searcher.rs
@@ -2,6 +2,7 @@ use crate::core::lookup::lookup_table::LookupTable;
 use crate::core::search::id_search_req::IdentifierSearchRequest;
 use crate::core::search::id_search_res::IdentifierSearchResult;
 
+#[allow(dead_code)]
 trait IdentifierSearcher<T> {
     /// Performs the search for given identifier in the lookup table in the given direction and level.
     /// Essentially looks for the first match in the direction for the given level and all levels below.

--- a/src/core/testutil/fixtures.rs
+++ b/src/core/testutil/fixtures.rs
@@ -25,7 +25,7 @@ pub fn random_membership_vector() -> MembershipVector {
 
 /// Generate a random port
 pub fn random_port() -> u16 {
-    rand::thread_rng().gen_range(1024..=65535)
+    rand::rng().random_range(1024..=65535)
 }
 
 /// Generate a random address

--- a/src/core/testutil/fixtures.rs
+++ b/src/core/testutil/fixtures.rs
@@ -4,12 +4,14 @@ use crate::core::{model, Address, ArrayLookupTable, Identifier, LookupTable, Mem
 use rand::Rng;
 use crate::core::model::direction::Direction;
 
-/// Generate a random identifier
+/// Generate a random identifier.
+#[cfg(test)]
 pub fn random_identifier() -> Identifier {
     Identifier::from_string(&random_hex_str(model::IDENTIFIER_SIZE_BYTES)).unwrap()
 }
 
-/// Generate n random identifiers sorted in ascending order
+/// Generate n random identifiers sorted in ascending order.
+#[cfg(test)]
 pub fn random_sorted_identifiers(n: usize) -> Vec<Identifier> {
     let mut ids = (0..n)
         .map(|_| random_identifier())
@@ -18,22 +20,26 @@ pub fn random_sorted_identifiers(n: usize) -> Vec<Identifier> {
     ids
 }
 
-/// Generate a random membership vector
+/// Generate a random membership vector.
+#[cfg(test)]
 pub fn random_membership_vector() -> MembershipVector {
     MembershipVector::from_string(&random_hex_str(model::IDENTIFIER_SIZE_BYTES)).unwrap()
 }
 
-/// Generate a random port
+/// Generate a random port.
+#[cfg(test)]
 pub fn random_port() -> u16 {
     rand::rng().random_range(1024..=65535)
 }
 
 /// Generate a random address
+#[cfg(test)]
 pub fn random_address() -> Address {
     Address::new("localhost", &random_port().to_string())
 }
 
 /// Generate a random network identity; ID, MembershipVector, Address.
+#[cfg(test)]
 pub fn random_network_identity() -> Identity<Address> {
     Identity::new(
         &random_identifier(),
@@ -43,11 +49,13 @@ pub fn random_network_identity() -> Identity<Address> {
 }
 
 /// Generate n random network identities; ID, MembershipVector, Address.
+#[cfg(test)]
 pub fn random_network_identities(n: usize) -> Vec<Identity<Address>> {
     (0..n).map(|_| random_network_identity()).collect()
 }
 
 /// Generates a random lookup table with 2 * n entries (n left and n right), and n levels.
+#[cfg(test)]
 pub fn random_network_lookup_table(n: usize) -> ArrayLookupTable<Address> {
     let mut lt = ArrayLookupTable::new();
     let ids = random_network_identities(2 * n);

--- a/src/core/testutil/fixtures.rs
+++ b/src/core/testutil/fixtures.rs
@@ -1,8 +1,15 @@
-use crate::core::model::identity::Identity;
-use crate::core::testutil::random::random_hex_str;
-use crate::core::{model, Address, ArrayLookupTable, Identifier, LookupTable, MembershipVector};
-use rand::Rng;
-use crate::core::model::direction::Direction;
+#[cfg(test)]
+mod test_imports {
+    pub use crate::core::model::direction::Direction;
+    pub use crate::core::model::identity::Identity;
+    pub use crate::core::testutil::random::random_hex_str;
+    pub use crate::core::{model, Address, ArrayLookupTable, Identifier, LookupTable, MembershipVector};
+    pub use rand::Rng;
+}
+
+#[cfg(test)]
+use test_imports::*;
+
 
 /// Generate a random identifier.
 #[cfg(test)]

--- a/src/core/testutil/random.rs
+++ b/src/core/testutil/random.rs
@@ -1,7 +1,11 @@
+/// Generate random bytes of the given size.
+#[cfg(test)]
 pub fn bytes(size: usize) -> Vec<u8> {
     (0..size).map(|_| rand::random::<u8>()).collect()
 }
 
+/// Generate a random hex string of the given size.
+#[cfg(test)]
 pub fn random_hex_str(size: usize) -> String {
     hex::encode(bytes(size))
 }

--- a/src/local/base_node.rs
+++ b/src/local/base_node.rs
@@ -69,7 +69,7 @@ impl fmt::Debug for LocalNode {
 impl Clone for LocalNode {
     fn clone(&self) -> Self {
         LocalNode {
-            id: self.id.clone(),
+            id: self.id,
             mem_vec: self.mem_vec,
             lt: self.lt.clone(),
         }

--- a/src/local/base_node.rs
+++ b/src/local/base_node.rs
@@ -7,7 +7,6 @@ use std::fmt::Formatter;
 use std::sync::Arc;
 
 /// LocalNode is a struct that represents a single node in the local implementation of the skip graph.
-
 struct LocalNode {
     id: Identifier,
     mem_vec: MembershipVector,

--- a/src/local/base_node.rs
+++ b/src/local/base_node.rs
@@ -4,17 +4,17 @@ use crate::core::{
 };
 use std::fmt;
 use std::fmt::Formatter;
-use std::sync::Arc;
+use std::rc::Rc;
 
 /// LocalNode is a struct that represents a single node in the local implementation of the skip graph.
 struct LocalNode {
     id: Identifier,
     mem_vec: MembershipVector,
-    lt: Box<dyn LookupTable<Arc<LocalNode>>>,
+    lt: Box<dyn LookupTable<Rc<LocalNode>>>,
 }
 
 impl Node for LocalNode {
-    type Address = Arc<LocalNode>;
+    type Address = Rc<LocalNode>;
 
     fn get_identifier(&self) -> &Identifier {
         &self.id
@@ -25,7 +25,7 @@ impl Node for LocalNode {
     }
 
     fn get_address(&self) -> Self::Address {
-        Arc::new(self.clone())
+        Rc::new(self.clone())
     }
 
     fn search_by_id(

--- a/src/local/base_node.rs
+++ b/src/local/base_node.rs
@@ -30,19 +30,19 @@ impl Node for LocalNode {
 
     fn search_by_id(
         &self,
-        req: &IdentifierSearchRequest,
+        _req: &IdentifierSearchRequest,
     ) -> anyhow::Result<IdentifierSearchResult<Self::Address>> {
         todo!()
     }
 
     fn search_by_mem_vec(
         &self,
-        req: &IdentifierSearchRequest,
+        _req: &IdentifierSearchRequest,
     ) -> anyhow::Result<IdentifierSearchResult<Self::Address>> {
         todo!()
     }
 
-    fn join(&self, introducer: Self::Address) -> anyhow::Result<()> {
+    fn join(&self, _introducer: Self::Address) -> anyhow::Result<()> {
         todo!()
     }
 }

--- a/src/local/base_node.rs
+++ b/src/local/base_node.rs
@@ -70,7 +70,7 @@ impl Clone for LocalNode {
     fn clone(&self) -> Self {
         LocalNode {
             id: self.id.clone(),
-            mem_vec: self.mem_vec.clone(),
+            mem_vec: self.mem_vec,
             lt: self.lt.clone(),
         }
     }


### PR DESCRIPTION
This PR enforces stricter linting by treating Clippy warnings as errors. It then fixes all those warnings hence resulting on Lint CI job to pass. Below lists the lint fix items:

### Codebase improvements:

* [`src/core/lookup/array_lookup_table.rs`](diffhunk://#diff-19dbb7f9cc445561c37ef0274d9b24a658f6d8fce02907101f3b6e8eb2446a17R29-R45): Added a default implementation for `ArrayLookupTable` and improved the `Debug` implementation by using `enumerate` in the loop.
* [`src/core/model/address.rs`](diffhunk://#diff-b72304fc7b8d1ca25c09546318f43ede517d269414f5e191063ac55c01c8dac0L21-R26): Simplified the `host` and `port` methods by removing unnecessary references.
* [`src/core/model/identifier.rs`](diffhunk://#diff-4b14f201259ff422130a0aeeaf5cdc21f92cade3b07f57edd3f6fe4d886ae8f3L83-R105): Replaced manual comparisons with `std::cmp::Ordering` in the `compare` method and removed redundant `clone` calls.

### Linting and testing improvements:

* [`Makefile`](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L10-R10): Updated the `install-lint` target to enforce warnings as errors in `cargo clippy`.
* [`src/core/testutil/fixtures.rs`](diffhunk://#diff-a700e81f90823ba0d251d3ce60358514aaf6ba97b0de4ccd682715899567c724L1-R21): Grouped test imports under a `mod test_imports` and added `#[cfg(test)]` to test functions to ensure they are only included in test builds.

### Miscellaneous changes:

* [`src/core/mod.rs`](diffhunk://#diff-252feb90e029bc42625d2adc67cc69e666a96b656515a7099fab4e966ad5634aL2-R2): Made the `model` module public.
* [`src/core/model/identity.rs`](diffhunk://#diff-94752461df5824dc669423f1833828455beafbda0ca9f5ef071f2e31eeeee337R42): Removed unnecessary `clone` calls and added missing imports for `Address` in test modules.
* [`src/core/model/memvec.rs`](diffhunk://#diff-c25c2cb5e337dd86b1a7df26be56418039d56dde8b6190786bf2ffbd9ce727afL137-R137): Simplified slice copying and removed redundant references in the `fmt` method.
* [`src/local/base_node.rs`](diffhunk://#diff-22b76824d9fcdd8e83622c568e7c6940bed2c066590cb39d9fabfa025344413eL7-R17): Replaced `Arc` with `Rc` for `LocalNode` to reduce overhead and updated method signatures to remove unused parameters.