### PR TITLE
[Feature] Implements `Network` trait and `MockNetwork`

### DIFF
--- a/src/core/model/identifier.rs
+++ b/src/core/model/identifier.rs
@@ -84,7 +84,7 @@ impl Display for ComparisonContext {
 }
 
 // Identifier represents a 32-byte unique identifier for a Skip Graph node.
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
 pub struct Identifier([u8; IDENTIFIER_SIZE_BYTES]);
 
 impl Identifier {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod core;
 mod local;
+mod network;
 
 pub fn add(left: u64, right: u64) -> u64 {
     left + right

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,18 +1,5 @@
 pub mod core;
 mod local;
-mod network;
-
-pub fn add(left: u64, right: u64) -> u64 {
-    left + right
-}
-
+// TODO: for the time being, the network module is solely used in testing.
 #[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn it_works() {
-        let result = add(2, 2);
-        assert_eq!(result, 4);
-    }
-}
+mod network;

--- a/src/network/mock/hub.rs
+++ b/src/network/mock/hub.rs
@@ -1,6 +1,6 @@
 use crate::core::Identifier;
 use crate::network::mock::network::MockNetwork;
-use crate::network::{Message, Network};
+use crate::network::{Message};
 use anyhow::{anyhow, Context};
 use std::cell::RefCell;
 use std::collections::HashMap;
@@ -23,7 +23,7 @@ impl NetworkHub {
         let mut inner_networks = inner_hub
             .networks
             .write()
-            .map_err(|e| anyhow!("Failed to acquire write lock on network hub"))?;
+            .map_err(|_| anyhow!("Failed to acquire write lock on network hub"))?;
         if inner_networks.contains_key(&identifier) {
             return Err(anyhow::anyhow!(
                 "Network with identifier {} already exists",

--- a/src/network/mock/hub.rs
+++ b/src/network/mock/hub.rs
@@ -48,11 +48,11 @@ impl NetworkHub {
         let inner_networks = self
             .networks
             .read()
-            .map_err(|e| anyhow!("Failed to acquire read lock on network hub"))?;
+            .map_err(|_| anyhow!("Failed to acquire read lock on network hub"))?;
         if let Some(network) = inner_networks.get(&message.target_node_id) {
             network
                 .borrow()
-                .send_message(message)
+                .incoming_message(message)
                 .context("Failed to send message through network")?;
             Ok(())
         } else {

--- a/src/network/mock/hub.rs
+++ b/src/network/mock/hub.rs
@@ -1,0 +1,43 @@
+use std::collections::HashMap;
+use std::sync::{Arc, RwLock};
+use anyhow::{anyhow, Context};
+use crate::core::Identifier;
+use crate::network::mock::network::MockNetwork;
+use crate::network::{Message, Network};
+
+pub struct NetworkHub {
+    networks: RwLock<HashMap<Identifier, Box<Arc<dyn Network>>>>,
+}
+
+impl NetworkHub {
+    pub fn new() -> Self {
+        NetworkHub {
+            networks: RwLock::new(HashMap::new()),
+        }
+    }
+
+    pub fn new_mock_network(&self, identifier: Identifier) -> anyhow::Result<Arc<MockNetwork>> {
+        let mut inner_networks = self.networks.write().map_err(|e| anyhow!("Failed to acquire write lock on network hub"))?;
+        if inner_networks.contains_key(&identifier) {
+            return Err(anyhow::anyhow!("Network with identifier {} already exists", identifier));
+        }
+        let mock_network = Arc::new(MockNetwork::new());
+        inner_networks.insert(identifier, Box::new(mock_network.clone() as Arc<dyn Network>));
+        Ok(mock_network)
+    }
+
+    pub fn get_network(&self, identifier: &Identifier) -> Option<Box<Arc<dyn Network>>> {
+        let inner_networks = self.networks.read().map_err(|e| anyhow!("Failed to acquire read lock on network hub")).ok()?;
+        inner_networks.get(identifier).cloned()
+    }
+    
+    pub fn route_message(&self, message: Message) -> anyhow::Result<()> {
+        let inner_networks = self.networks.read().map_err(|e| anyhow!("Failed to acquire read lock on network hub"))?;
+        if let Some(network) = inner_networks.get(&message.target_node_id) {
+            network.send_message(message).context("Failed to send message through network")?;
+            Ok(())
+        } else {
+            Err(anyhow!("Network with identifier {} not found", message.target_node_id))
+        }
+    }
+}

--- a/src/network/mock/hub.rs
+++ b/src/network/mock/hub.rs
@@ -1,3 +1,4 @@
+use std::cell::RefCell;
 use crate::core::Identifier;
 use crate::network::mock::network::MockNetwork;
 use crate::network::{Message, Network};
@@ -16,10 +17,7 @@ impl NetworkHub {
         }
     }
 
-    pub fn new_mock_network(
-        self: &Arc<Self>,
-        identifier: Identifier,
-    ) -> anyhow::Result<Arc<Mutex<MockNetwork>>> {
+    pub fn new_mock_network(self: &Arc<Self>, identifier: Identifier, ) -> anyhow::Result<Rc<RefCell<MockNetwork>>> {
         let mut inner_networks = self
             .networks
             .write()
@@ -50,8 +48,9 @@ impl NetworkHub {
             .read()
             .map_err(|e| anyhow!("Failed to acquire read lock on network hub"))?;
         if let Some(mutex_network) = inner_networks.get(&message.target_node_id) {
-            let network = mutex_network.lock().
-                map_err(|e| { anyhow!("Failed to acquire lock on network {e}") })?;
+            let network = mutex_network
+                .lock()
+                .map_err(|e| anyhow!("Failed to acquire lock on network {e}"))?;
             network
                 .send_message(message)
                 .context("Failed to send message through network")?;

--- a/src/network/mock/hub.rs
+++ b/src/network/mock/hub.rs
@@ -6,7 +6,7 @@ use crate::network::mock::network::MockNetwork;
 use crate::network::{Message, Network};
 
 pub struct NetworkHub {
-    networks: RwLock<HashMap<Identifier, Box<Arc<dyn Network>>>>,
+    networks: RwLock<HashMap<Identifier, Arc<MockNetwork>>>,
 }
 
 impl NetworkHub {
@@ -22,12 +22,12 @@ impl NetworkHub {
             return Err(anyhow::anyhow!("Network with identifier {} already exists", identifier));
         }
         let mock_network = Arc::new(MockNetwork::new(self.clone()));
-        inner_networks.insert(identifier, Box::new(mock_network.clone() as Arc<dyn Network>));
+        inner_networks.insert(identifier, mock_network.clone());
         Ok(mock_network)
     }
 
-    pub fn get_network(&self, identifier: &Identifier) -> Option<Box<Arc<dyn Network>>> {
-        let inner_networks = self.networks.read().map_err(|e| anyhow!("Failed to acquire read lock on network hub")).ok()?;
+    pub fn get_network(&self, identifier: &Identifier) -> Option<Arc<MockNetwork>> {
+        let inner_networks = self.networks.read().map_err(|_| anyhow!("Failed to acquire read lock on network hub")).ok()?;
         inner_networks.get(identifier).cloned()
     }
 

--- a/src/network/mock/hub.rs
+++ b/src/network/mock/hub.rs
@@ -1,12 +1,12 @@
-use std::collections::HashMap;
-use std::sync::{Arc, RwLock};
-use anyhow::{anyhow, Context};
 use crate::core::Identifier;
 use crate::network::mock::network::MockNetwork;
 use crate::network::{Message, Network};
+use anyhow::{anyhow, Context};
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex, RwLock};
 
 pub struct NetworkHub {
-    networks: RwLock<HashMap<Identifier, Arc<MockNetwork>>>,
+    networks: RwLock<HashMap<Identifier, Arc<Mutex<MockNetwork>>>>,
 }
 
 impl NetworkHub {
@@ -16,28 +16,51 @@ impl NetworkHub {
         }
     }
 
-    pub fn new_mock_network(self: &Arc<Self>, identifier: Identifier) -> anyhow::Result<Arc<MockNetwork>> {
-        let mut inner_networks = self.networks.write().map_err(|e| anyhow!("Failed to acquire write lock on network hub"))?;
+    pub fn new_mock_network(
+        self: &Arc<Self>,
+        identifier: Identifier,
+    ) -> anyhow::Result<Arc<Mutex<MockNetwork>>> {
+        let mut inner_networks = self
+            .networks
+            .write()
+            .map_err(|e| anyhow!("Failed to acquire write lock on network hub"))?;
         if inner_networks.contains_key(&identifier) {
-            return Err(anyhow::anyhow!("Network with identifier {} already exists", identifier));
+            return Err(anyhow::anyhow!(
+                "Network with identifier {} already exists",
+                identifier
+            ));
         }
-        let mock_network = Arc::new(MockNetwork::new(self.clone()));
+        let mock_network = Arc::new(Mutex::new(MockNetwork::new(self.clone())));
         inner_networks.insert(identifier, mock_network.clone());
         Ok(mock_network)
     }
 
-    pub fn get_network(&self, identifier: &Identifier) -> Option<Arc<MockNetwork>> {
-        let inner_networks = self.networks.read().map_err(|_| anyhow!("Failed to acquire read lock on network hub")).ok()?;
+    pub fn get_network(&self, identifier: &Identifier) -> Option<Arc<Mutex<MockNetwork>>> {
+        let inner_networks = self
+            .networks
+            .read()
+            .map_err(|_| anyhow!("Failed to acquire read lock on network hub"))
+            .ok()?;
         inner_networks.get(identifier).cloned()
     }
 
     pub fn route_message(&self, message: Message) -> anyhow::Result<()> {
-        let inner_networks = self.networks.read().map_err(|e| anyhow!("Failed to acquire read lock on network hub"))?;
-        if let Some(network) = inner_networks.get(&message.target_node_id) {
-            network.send_message(message).context("Failed to send message through network")?;
+        let inner_networks = self
+            .networks
+            .read()
+            .map_err(|e| anyhow!("Failed to acquire read lock on network hub"))?;
+        if let Some(mutex_network) = inner_networks.get(&message.target_node_id) {
+            let network = mutex_network.lock().
+                map_err(|e| { anyhow!("Failed to acquire lock on network {e}") })?;
+            network
+                .send_message(message)
+                .context("Failed to send message through network")?;
             Ok(())
         } else {
-            Err(anyhow!("Network with identifier {} not found", message.target_node_id))
+            Err(anyhow!(
+                "Network with identifier {} not found",
+                message.target_node_id
+            ))
         }
     }
 }

--- a/src/network/mock/hub.rs
+++ b/src/network/mock/hub.rs
@@ -35,15 +35,6 @@ impl NetworkHub {
         Ok(mock_network)
     }
 
-    pub fn get_network(&self, identifier: &Identifier) -> Option<Rc<RefCell<MockNetwork>>> {
-        let inner_networks = self
-            .networks
-            .read()
-            .map_err(|_| anyhow!("Failed to acquire read lock on network hub"))
-            .ok()?;
-        inner_networks.get(identifier).cloned()
-    }
-
     pub fn route_message(&self, message: Message) -> anyhow::Result<()> {
         let inner_networks = self
             .networks

--- a/src/network/mock/mod.rs
+++ b/src/network/mock/mod.rs
@@ -1,3 +1,4 @@
 mod network;
 mod hub;
+#[cfg(test)]
 mod network_test;

--- a/src/network/mock/mod.rs
+++ b/src/network/mock/mod.rs
@@ -1,0 +1,2 @@
+mod network;
+mod hub;

--- a/src/network/mock/mod.rs
+++ b/src/network/mock/mod.rs
@@ -1,4 +1,6 @@
+#[cfg(test)]
 mod network;
+#[cfg(test)]
 mod hub;
 #[cfg(test)]
 mod network_test;

--- a/src/network/mock/mod.rs
+++ b/src/network/mock/mod.rs
@@ -1,2 +1,3 @@
 mod network;
 mod hub;
+mod network_test;

--- a/src/network/mock/network.rs
+++ b/src/network/mock/network.rs
@@ -52,14 +52,4 @@ impl Network for MockNetwork {
         self.processor = Some(processor);
         Ok(())
     }
-
-    fn start(&mut self) -> anyhow::Result<()> {
-        // No-op for mock network
-        Ok(())
-    }
-
-    fn stop(&mut self) -> anyhow::Result<()> {
-        // No-op for mock network
-        Ok(())
-    }
 }

--- a/src/network/mock/network.rs
+++ b/src/network/mock/network.rs
@@ -1,0 +1,43 @@
+use std::sync::Arc;
+use anyhow::Context;
+use crate::network::{Message, MessageProcessor, Network};
+use crate::network::mock::hub::NetworkHub;
+
+pub struct MockNetwork {
+    hub : Arc<NetworkHub>,
+    processor: Option<Box<dyn MessageProcessor>>,
+}
+
+impl MockNetwork {
+    pub fn new(hub : Arc<NetworkHub>) -> Self {
+        MockNetwork {
+            hub: hub.clone(),
+            processor: None,
+        }
+    }
+}
+
+impl Network for MockNetwork {
+    fn send_message(&self, message: Message) -> anyhow::Result<()> {
+        self.hub.route_message(message).context("Failed to route message")?;
+        Ok(())
+    }
+
+    fn register_processor(&mut self, processor: Box<dyn MessageProcessor>) -> anyhow::Result<()> {
+        if self.processor.is_some() {
+            return Err(anyhow::anyhow!("A message processor is already registered"));
+        }
+        self.processor = Some(processor);
+        Ok(())
+    }
+
+    fn start(&mut self) -> anyhow::Result<()> {
+        // No-op for mock network
+        Ok(())
+    }
+
+    fn stop(&mut self) -> anyhow::Result<()> {
+        // No-op for mock network
+        Ok(())
+    }
+}

--- a/src/network/mock/network.rs
+++ b/src/network/mock/network.rs
@@ -1,11 +1,11 @@
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use anyhow::Context;
 use crate::network::{Message, MessageProcessor, Network};
 use crate::network::mock::hub::NetworkHub;
 
 pub struct MockNetwork {
     hub : Arc<NetworkHub>,
-    processor: Option<Box<dyn MessageProcessor>>,
+    processor: Option<Box<Arc<Mutex<dyn MessageProcessor>>>>,
 }
 
 impl MockNetwork {
@@ -23,7 +23,7 @@ impl Network for MockNetwork {
         Ok(())
     }
 
-    fn register_processor(&mut self, processor: Box<dyn MessageProcessor>) -> anyhow::Result<()> {
+    fn register_processor(&mut self, processor: Box<Arc<Mutex<dyn MessageProcessor>>>) -> anyhow::Result<()> {
         if self.processor.is_some() {
             return Err(anyhow::anyhow!("A message processor is already registered"));
         }

--- a/src/network/mock/network.rs
+++ b/src/network/mock/network.rs
@@ -16,6 +16,21 @@ impl MockNetwork {
             processor: None,
         }
     }
+
+    pub fn incoming_message(
+        &self,
+        message: Message,
+    ) -> anyhow::Result<()> {
+        if let Some(ref processor) = self.processor {
+            processor
+                .borrow_mut()
+                .process_incoming_message(message)
+                .context("Failed to process incoming message")?;
+            Ok(())
+        } else {
+            Err(anyhow::anyhow!("No message processor registered"))
+        }
+    }
 }
 
 impl Network for MockNetwork {

--- a/src/network/mock/network_test.rs
+++ b/src/network/mock/network_test.rs
@@ -1,20 +1,20 @@
-use std::collections::HashSet;
-use std::sync::{Arc, Mutex};
-use crate::network::{Message, MessageProcessor};
 use crate::network::MessageType::TestMessage;
-use crate::network::mock::network::MockNetwork;
+use crate::network::{Message, MessageProcessor, Network};
+use std::cell::RefCell;
+use std::collections::HashSet;
+use std::rc::Rc;
+use crate::core::testutil::fixtures::random_identifier;
+use crate::network::mock::hub::NetworkHub;
 
 struct MockMessageProcessor {
-    seen : HashSet<String>,
-    net: Arc<Mutex<MockNetwork>>,
+    seen: HashSet<String>,
 }
 
 impl MockMessageProcessor {
-    fn new(net: Arc<Mutex<MockNetwork>>) -> Arc<Mutex<Self>> {
-        Arc::new(Mutex::new((MockMessageProcessor {
+    fn new() -> Rc<RefCell<Self>> {
+        Rc::new(RefCell::new(MockMessageProcessor {
             seen: HashSet::new(),
-            net,
-        })))
+        }))
     }
 
     fn has_seen(&self, content: &str) -> bool {
@@ -28,62 +28,59 @@ impl MessageProcessor for MockMessageProcessor {
             TestMessage(content) => {
                 self.seen.insert(content);
                 Ok(())
-            },
-            _ => {
-                Err(anyhow::anyhow!(format!("Unknown message type {:?}", message.message_type)))
             }
+            _ => Err(anyhow::anyhow!(format!(
+                "Unknown message type {:?}",
+                message.message_type
+            ))),
         }
     }
 }
 
-#[cfg(test)]
-mod network_test {
-    use crate::core::testutil::fixtures::random_identifier;
+/// Test for the MockMessageProcessor to ensure it correctly processes messages.
+#[test]
+fn test_mock_message_processor() {
+    let hub = NetworkHub::new();
+    let identifier = random_identifier();
+    let mock_network = NetworkHub::new_mock_network(hub, identifier).unwrap();
+    let mut processor = MockMessageProcessor::new();
+    let message = Message {
+        message_type: TestMessage("Hello, World!".to_string()),
+        target_node_id: random_identifier(),
+        payload: Box::new(()),
+    };
+
+    assert!(!processor.borrow().has_seen("Hello, World!"));
+    processor
+        .borrow_mut()
+        .process_incoming_message(message)
+        .unwrap();
+    assert!(processor.borrow().has_seen("Hello, World!"));
+}
+
+#[test]
+fn test_hub_route_message() {
     use crate::network::mock::hub::NetworkHub;
-    use crate::network::Network;
-    use super::*;
 
-    /// Test for the MockMessageProcessor to ensure it correctly processes messages.
-    #[test]
-    fn test_mock_message_processor() {
-        let hub = Arc::new(NetworkHub::new());
-        let identifier = random_identifier();
-        let mock_network = hub.new_mock_network(identifier).unwrap();
-        let mut processor = MockMessageProcessor::new(mock_network.clone());
-        let message = Message {
-            message_type: TestMessage("Hello, World!".to_string()),
-            target_node_id: random_identifier(),
-            payload: Box::new(()),
-        };
+    let hub = NetworkHub::new();
 
-        assert!(!processor.lock().unwrap().has_seen("Hello, World!"));
-        processor.lock().unwrap().process_incoming_message(message).unwrap();
-        assert!(processor.lock().unwrap().has_seen("Hello, World!"));
-    }
+    let id_1 = random_identifier();
+    let mock_net_1 = NetworkHub::new_mock_network(hub.clone(), id_1).unwrap();
+    let msg_proc_1 = MockMessageProcessor::new();
+    mock_net_1
+        .borrow_mut()
+        .register_processor(Box::new(msg_proc_1.clone()))
+        .expect("Failed to register message processor");
 
-    #[test]
-    fn test_hub_route_message() {
-        use crate::network::mock::hub::NetworkHub;
+    let id_2 = random_identifier();
+    let mock_net_2 = NetworkHub::new_mock_network(hub, id_2).unwrap();
 
-        let hub = Arc::new(NetworkHub::new());
-        
-        let id_1 = random_identifier();
-        let mock_net_1 = hub.new_mock_network(id_1).unwrap();
-        let msg_proc_1 = MockMessageProcessor::new(mock_net_1.clone());
-        mock_net_1.lock().unwrap().register_processor(Box::new(msg_proc_1.clone())).expect("Failed to \
-        register message processor");
+    let message = Message {
+        message_type: TestMessage("Test message".to_string()),
+        target_node_id: id_1,
+        payload: Box::new(()),
+    };
 
-        let id_2 = random_identifier();
-        let mock_net_2 = hub.new_mock_network(id_2).unwrap();
-
-        
-        let message = Message {
-            message_type: TestMessage("Test message".to_string()),
-            target_node_id: id_1.clone(),
-            payload: Box::new(()),
-        };
-
-        assert!(!msg_proc_1.lock().unwrap().has_seen("Test message"));
-        assert!(mock_net_2.lock().unwrap().send_message(message).is_ok());
-    }
+    assert!(!msg_proc_1.borrow().has_seen("Test message"));
+    assert!(mock_net_2.borrow().send_message(message).is_ok());
 }

--- a/src/network/mock/network_test.rs
+++ b/src/network/mock/network_test.rs
@@ -81,12 +81,6 @@ fn test_hub_route_message() {
         payload: Box::new(()),
     };
 
-    let message2 = Message {
-        message_type: TestMessage("Test message2".to_string()),
-        target_node_id: id_1,
-        payload: Box::new(()),
-    };
-
     assert!(!msg_proc_1.borrow().has_seen("Test message"));
     assert!(mock_net_2.borrow().send_message(message).is_ok());
     assert!(msg_proc_1.borrow().has_seen("Test message"));

--- a/src/network/mock/network_test.rs
+++ b/src/network/mock/network_test.rs
@@ -1,20 +1,20 @@
 use std::collections::HashSet;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use crate::network::{Message, MessageProcessor};
 use crate::network::MessageType::TestMessage;
 use crate::network::mock::network::MockNetwork;
 
 struct MockMessageProcessor {
     seen : HashSet<String>,
-    net: Arc<MockNetwork>,
+    net: Arc<Mutex<MockNetwork>>,
 }
 
 impl MockMessageProcessor {
-    fn new(net: Arc<MockNetwork>) -> Self {
-        MockMessageProcessor {
+    fn new(net: Arc<Mutex<MockNetwork>>) -> Arc<Mutex<Self>> {
+        Arc::new(Mutex::new((MockMessageProcessor {
             seen: HashSet::new(),
             net,
-        }
+        })))
     }
 
     fn has_seen(&self, content: &str) -> bool {
@@ -40,12 +40,13 @@ impl MessageProcessor for MockMessageProcessor {
 mod network_test {
     use crate::core::testutil::fixtures::random_identifier;
     use crate::network::mock::hub::NetworkHub;
+    use crate::network::Network;
     use super::*;
 
     /// Test for the MockMessageProcessor to ensure it correctly processes messages.
     #[test]
     fn test_mock_message_processor() {
-        let hub = NetworkHub::new();
+        let hub = Arc::new(NetworkHub::new());
         let identifier = random_identifier();
         let mock_network = hub.new_mock_network(identifier).unwrap();
         let mut processor = MockMessageProcessor::new(mock_network.clone());
@@ -55,20 +56,26 @@ mod network_test {
             payload: Box::new(()),
         };
 
-        assert!(!processor.has_seen("Hello, World!"));
-        processor.process_incoming_message(message).unwrap();
-        assert!(processor.has_seen("Hello, World!"));
+        assert!(!processor.lock().unwrap().has_seen("Hello, World!"));
+        processor.lock().unwrap().process_incoming_message(message).unwrap();
+        assert!(processor.lock().unwrap().has_seen("Hello, World!"));
     }
-    
+
+    #[test]
     fn test_hub_route_message() {
         use crate::network::mock::hub::NetworkHub;
 
-        let hub = NetworkHub::new();
+        let hub = Arc::new(NetworkHub::new());
         
         let id_1 = random_identifier();
-        let mock_network_1 = hub.get_network(&id_1).unwrap();
+        let mock_net_1 = hub.new_mock_network(id_1).unwrap();
+        let msg_proc_1 = MockMessageProcessor::new(mock_net_1.clone());
+        mock_net_1.lock().unwrap().register_processor(Box::new(msg_proc_1.clone())).expect("Failed to \
+        register message processor");
+
         let id_2 = random_identifier();
-        let mock_network_2 = hub.get_network(&id_2).unwrap();
+        let mock_net_2 = hub.new_mock_network(id_2).unwrap();
+
         
         let message = Message {
             message_type: TestMessage("Test message".to_string()),
@@ -76,10 +83,7 @@ mod network_test {
             payload: Box::new(()),
         };
 
-        // Route the message through the hub
-        assert!(hub.route_message(message).is_ok());
-
-        // Verify that the network can be retrieved from the hub
-        assert!(hub.get_network(&id_1).is_some());
+        assert!(!msg_proc_1.lock().unwrap().has_seen("Test message"));
+        assert!(mock_net_2.lock().unwrap().send_message(message).is_ok());
     }
 }

--- a/src/network/mock/network_test.rs
+++ b/src/network/mock/network_test.rs
@@ -1,4 +1,4 @@
-use crate::network::MessageType::TestMessage;
+use crate::network::Payload::TestMessage;
 use crate::network::{Message, MessageProcessor, Network};
 use std::cell::RefCell;
 use std::collections::HashSet;
@@ -24,14 +24,14 @@ impl MockMessageProcessor {
 
 impl MessageProcessor for MockMessageProcessor {
     fn process_incoming_message(&mut self, message: Message) -> anyhow::Result<()> {
-        match message.message_type {
+        match message.payload {
             TestMessage(content) => {
                 self.seen.insert(content);
                 Ok(())
             }
             _ => Err(anyhow::anyhow!(format!(
                 "Unknown message type {:?}",
-                message.message_type
+                message.payload
             ))),
         }
     }
@@ -45,7 +45,7 @@ fn test_mock_message_processor() {
     let mock_network = NetworkHub::new_mock_network(hub, identifier).unwrap();
     let mut processor = MockMessageProcessor::new();
     let message = Message {
-        message_type: TestMessage("Hello, World!".to_string()),
+        payload: TestMessage("Hello, World!".to_string()),
         target_node_id: random_identifier(),
         payload: Box::new(()),
     };
@@ -76,7 +76,7 @@ fn test_hub_route_message() {
     let mock_net_2 = NetworkHub::new_mock_network(hub, id_2).unwrap();
 
     let message = Message {
-        message_type: TestMessage("Test message".to_string()),
+        payload: TestMessage("Test message".to_string()),
         target_node_id: id_1,
         payload: Box::new(()),
     };

--- a/src/network/mock/network_test.rs
+++ b/src/network/mock/network_test.rs
@@ -1,0 +1,85 @@
+use std::collections::HashSet;
+use std::sync::Arc;
+use crate::network::{Message, MessageProcessor};
+use crate::network::MessageType::TestMessage;
+use crate::network::mock::network::MockNetwork;
+
+struct MockMessageProcessor {
+    seen : HashSet<String>,
+    net: Arc<MockNetwork>,
+}
+
+impl MockMessageProcessor {
+    fn new(net: Arc<MockNetwork>) -> Self {
+        MockMessageProcessor {
+            seen: HashSet::new(),
+            net,
+        }
+    }
+
+    fn has_seen(&self, content: &str) -> bool {
+        self.seen.contains(content)
+    }
+}
+
+impl MessageProcessor for MockMessageProcessor {
+    fn process_incoming_message(&mut self, message: Message) -> anyhow::Result<()> {
+        match message.message_type {
+            TestMessage(content) => {
+                self.seen.insert(content);
+                Ok(())
+            },
+            _ => {
+                Err(anyhow::anyhow!(format!("Unknown message type {:?}", message.message_type)))
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod network_test {
+    use crate::core::testutil::fixtures::random_identifier;
+    use crate::network::mock::hub::NetworkHub;
+    use super::*;
+
+    /// Test for the MockMessageProcessor to ensure it correctly processes messages.
+    #[test]
+    fn test_mock_message_processor() {
+        let hub = NetworkHub::new();
+        let identifier = random_identifier();
+        let mock_network = hub.new_mock_network(identifier).unwrap();
+        let mut processor = MockMessageProcessor::new(mock_network.clone());
+        let message = Message {
+            message_type: TestMessage("Hello, World!".to_string()),
+            target_node_id: random_identifier(),
+            payload: Box::new(()),
+        };
+
+        assert!(!processor.has_seen("Hello, World!"));
+        processor.process_incoming_message(message).unwrap();
+        assert!(processor.has_seen("Hello, World!"));
+    }
+    
+    fn test_hub_route_message() {
+        use crate::network::mock::hub::NetworkHub;
+
+        let hub = NetworkHub::new();
+        
+        let id_1 = random_identifier();
+        let mock_network_1 = hub.get_network(&id_1).unwrap();
+        let id_2 = random_identifier();
+        let mock_network_2 = hub.get_network(&id_2).unwrap();
+        
+        let message = Message {
+            message_type: TestMessage("Test message".to_string()),
+            target_node_id: id_1.clone(),
+            payload: Box::new(()),
+        };
+
+        // Route the message through the hub
+        assert!(hub.route_message(message).is_ok());
+
+        // Verify that the network can be retrieved from the hub
+        assert!(hub.get_network(&id_1).is_some());
+    }
+}

--- a/src/network/mock/network_test.rs
+++ b/src/network/mock/network_test.rs
@@ -81,6 +81,13 @@ fn test_hub_route_message() {
         payload: Box::new(()),
     };
 
+    let message2 = Message {
+        message_type: TestMessage("Test message2".to_string()),
+        target_node_id: id_1,
+        payload: Box::new(()),
+    };
+
     assert!(!msg_proc_1.borrow().has_seen("Test message"));
     assert!(mock_net_2.borrow().send_message(message).is_ok());
+    assert!(msg_proc_1.borrow().has_seen("Test message"));
 }

--- a/src/network/mod.rs
+++ b/src/network/mod.rs
@@ -4,6 +4,7 @@ use std::any::Any;
 use crate::core::Identifier;
 
 /// MessageType enum defines the types of messages that can be sent over the network.
+#[derive(Debug)]
 pub enum MessageType {
     TestMessage(String), // A message for testing purposes, it is a simple string message, and is not used in production.
 }

--- a/src/network/mod.rs
+++ b/src/network/mod.rs
@@ -1,6 +1,7 @@
 pub mod mock;
 
 use std::any::Any;
+use std::sync::{Arc, Mutex};
 use crate::core::Identifier;
 
 /// MessageType enum defines the types of messages that can be sent over the network.
@@ -29,7 +30,7 @@ pub trait Network: Send + Sync {
     /// Registers a message processor to handle incoming messages. 
     /// At any point in time, there can be only one processor registered.
     /// Registering a new processor is illegal if there is already a processor registered, and causes an error.
-    fn register_processor(&mut self, processor: Box<dyn MessageProcessor>) -> anyhow::Result<()>;
+    fn register_processor(&mut self, processor: Box<Arc<Mutex<dyn MessageProcessor>>>) -> anyhow::Result<()>;
 
     /// Starts the network service.
     fn start(&mut self) -> anyhow::Result<()>;

--- a/src/network/mod.rs
+++ b/src/network/mod.rs
@@ -5,15 +5,15 @@ use std::any::Any;
 use std::cell::RefCell;
 use std::rc::Rc;
 
-/// MessageType enum defines the types of messages that can be sent over the network.
+/// Payload enum defines the semantics of the message payload that can be sent over the network.
 #[derive(Debug)]
-pub enum MessageType {
-    TestMessage(String), // A message for testing purposes, it is a simple string message, and is not used in production.
+pub enum Payload {
+    TestMessage(String), // A payload for testing purposes, it is a simple string message, and is not used in production.
 }
 
 /// Message struct represents a message that can be sent over the network.
 pub struct Message {
-    pub message_type: MessageType,
+    pub payload: Payload,
     pub target_node_id: Identifier,
 }
 

--- a/src/network/mod.rs
+++ b/src/network/mod.rs
@@ -1,7 +1,6 @@
 pub mod mock;
 
 use crate::core::Identifier;
-use std::any::Any;
 use std::cell::RefCell;
 use std::rc::Rc;
 

--- a/src/network/mod.rs
+++ b/src/network/mod.rs
@@ -35,10 +35,4 @@ pub trait Network {
         &mut self,
         processor: Box<Rc<RefCell<dyn MessageProcessor>>>,
     ) -> anyhow::Result<()>;
-
-    /// Starts the network service.
-    fn start(&mut self) -> anyhow::Result<()>;
-
-    /// Stops the network service.
-    fn stop(&mut self) -> anyhow::Result<()>;
 }

--- a/src/network/mod.rs
+++ b/src/network/mod.rs
@@ -15,7 +15,6 @@ pub enum MessageType {
 pub struct Message {
     pub message_type: MessageType,
     pub target_node_id: Identifier,
-    pub payload: Box<dyn Any + Send>,
 }
 
 /// MessageProcessor trait defines the entity that processes the incoming network messages at this node.

--- a/src/network/mod.rs
+++ b/src/network/mod.rs
@@ -1,4 +1,7 @@
+pub mod mock;
+
 use std::any::Any;
+use crate::core::Identifier;
 
 /// MessageType enum defines the types of messages that can be sent over the network.
 pub enum MessageType {
@@ -8,6 +11,7 @@ pub enum MessageType {
 /// Message struct represents a message that can be sent over the network.
 pub struct Message {
     pub message_type: MessageType,
+    pub target_node_id: Identifier,
     pub payload: Box<dyn Any + Send>
 }
 

--- a/src/network/mod.rs
+++ b/src/network/mod.rs
@@ -1,0 +1,34 @@
+use std::any::Any;
+
+/// MessageType enum defines the types of messages that can be sent over the network.
+pub enum MessageType {
+    TestMessage(String), // A message for testing purposes, it is a simple string message, and is not used in production.
+}
+
+/// Message struct represents a message that can be sent over the network.
+pub struct Message {
+    pub message_type: MessageType,
+    pub payload: Box<dyn Any + Send>
+}
+
+/// MessageProcessor trait defines the entity that processes the incoming network messages at this node.
+pub trait MessageProcessor: Send + Sync {
+    fn process_incoming_message(&mut self, message: Message) -> anyhow::Result<()>;
+}
+
+/// Network trait defines the interface for a network service that can send and receive messages.
+pub trait Network: Send + Sync {
+    /// Sends a message to the network.
+    fn send_message(&self, message: Message) -> anyhow::Result<()>;
+
+    /// Registers a message processor to handle incoming messages. 
+    /// At any point in time, there can be only one processor registered.
+    /// Registering a new processor is illegal if there is already a processor registered, and causes an error.
+    fn register_processor(&mut self, processor: Box<dyn MessageProcessor>) -> anyhow::Result<()>;
+
+    /// Starts the network service.
+    fn start(&mut self) -> anyhow::Result<()>;
+
+    /// Stops the network service.
+    fn stop(&mut self) -> anyhow::Result<()>;
+}


### PR DESCRIPTION
This PR implements the interface for the `Network` trait that is the P2P networking layer of the Skip Graph node. It also implements a `MockNetwork` struct that is a simulation layer that mimics the behavior of the actual networking layer for testing purposes. The `MockNetwork` instances are interconnected via an in-memory `Hub` that routes messages completely in an in-memory fashion without relying on any actual networking primitive implementation.