### PR TITLE
[Feature] Enable Networking Infrastructure for Skip Graph Nodes

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,3 @@
 pub mod core;
 mod node;
-// TODO: for the time being, the network module is solely used in testing.
-#[cfg(test)]
 mod network;

--- a/src/network/mock/mod.rs
+++ b/src/network/mock/mod.rs
@@ -4,3 +4,5 @@ mod hub;
 mod network;
 #[cfg(test)]
 mod network_test;
+#[cfg(test)]
+pub mod noop_network;

--- a/src/network/mock/noop_network.rs
+++ b/src/network/mock/noop_network.rs
@@ -1,0 +1,28 @@
+use crate::network::{Message, MessageProcessor, Network};
+
+/// A no-operation network implementation that ignores all messages and processor registrations.
+/// This is useful for testing components that depend on the Network trait without performing any real networking.
+pub struct NoopNetwork {
+
+}
+
+impl Network for NoopNetwork {
+    fn send_message(&self, _message: Message) -> anyhow::Result<()> {
+        Ok(())
+    }
+
+    fn register_processor(&self, _processor: MessageProcessor) -> anyhow::Result<()> {
+        Ok(())
+    }
+
+    fn clone_box(&self) -> Box<dyn Network> {
+        Box::new(NoopNetwork {})
+    }
+}
+
+impl NoopNetwork {
+    /// Creates a new instance of NoopNetwork.
+    pub fn new() -> Self {
+        NoopNetwork {}
+    }
+}

--- a/src/network/mod.rs
+++ b/src/network/mod.rs
@@ -41,6 +41,11 @@ pub trait Network: Send + Sync {
     /// (e.g., using Arc for shared ownership). Changes made through one instance should be
     /// visible in all cloned instances. This is the standard cloning behavior for all
     /// Network implementations.
-    #[allow(dead_code)]
     fn clone_box(&self) -> Box<dyn Network>;
+}
+
+impl Clone for Box<dyn Network> {
+    fn clone(&self) -> Self {
+        self.clone_box()
+    }
 }

--- a/src/network/mod.rs
+++ b/src/network/mod.rs
@@ -2,6 +2,7 @@ pub mod mock;
 mod processor;
 
 use crate::core::Identifier;
+#[allow(unused)]
 pub use processor::MessageProcessor;
 
 /// Payload enum defines the semantics of the message payload that can be sent over the network.

--- a/src/node/base_node.rs
+++ b/src/node/base_node.rs
@@ -192,6 +192,7 @@ mod tests {
         span_fixture,
     };
     use crate::core::ArrayLookupTable;
+    use crate::network::mock::noop_network::NoopNetwork;
 
     #[test]
     fn test_base_node() {
@@ -201,6 +202,7 @@ mod tests {
             id,
             mem_vec,
             lt: Box::new(ArrayLookupTable::new(&span_fixture())),
+            net: Box::new(NoopNetwork::new()),
         };
         assert_eq!(node.get_identifier(), &id);
         assert_eq!(node.get_membership_vector(), &mem_vec);

--- a/src/node/base_node.rs
+++ b/src/node/base_node.rs
@@ -7,7 +7,7 @@ use crate::node::Node;
 use std::fmt;
 use std::fmt::Formatter;
 use crate::network::{Message, MessageProcessorCore, Network};
-#[cfg(test)]
+#[cfg(test)] // TODO: Remove once BaseNode is used in production code.
 use crate::network::MessageProcessor;
 
 // TODO: Remove #[allow(dead_code)] once BaseNode is used in production code.
@@ -154,7 +154,7 @@ impl MessageProcessorCore for BaseNode {
 impl BaseNode {
     /// Create a new `BaseNode` with the provided identifier, membership vector
     /// and lookup table.
-    #[cfg(test)]
+    #[cfg(test)] // TODO: Remove once BaseNode is used in production code.
     pub(crate) fn new(id: Identifier, mem_vec: MembershipVector, lt: Box<dyn LookupTable>, net: Box<dyn Network>) -> anyhow::Result<Self> {
         let clone_net = net.clone();
         let node = BaseNode { id, mem_vec, lt, net};

--- a/src/node/search_by_id_test.rs
+++ b/src/node/search_by_id_test.rs
@@ -30,7 +30,7 @@ fn test_search_by_id_singleton_fallback() {
         mem_vec,
         Box::new(ArrayLookupTable::new(&span_fixture())),
         Box::new(NoopNetwork::new()),
-    );
+    ).expect("Failed to create BaseNode");
 
     // Left and right searches for identifiers 5 and 15
     let cases = [
@@ -77,7 +77,7 @@ fn test_search_by_id_found_left_direction() {
             random_membership_vector(),
             Box::new(lt.clone()),
             Box::new(NoopNetwork::new()),
-        );
+        ).expect("Failed to create BaseNode");
 
         let direction = Direction::Left;
         let req = IdentifierSearchRequest::new(target, lvl, direction);
@@ -128,7 +128,7 @@ fn test_search_by_id_found_right_direction() {
             random_membership_vector(),
             Box::new(lt.clone()),
             Box::new(NoopNetwork::new()),
-        );
+        ).expect("Failed to create BaseNode");
 
         let actual_result = node.search_by_id(&req).unwrap();
 
@@ -194,7 +194,7 @@ fn test_search_by_id_not_found_left_direction() {
             random_membership_vector(),
             Box::new(lt.clone()),
             Box::new(NoopNetwork::new()),
-        );
+        ).expect("Failed to create BaseNode");
 
         let direction = Direction::Left;
         let req = IdentifierSearchRequest::new(target, lvl, direction);
@@ -255,7 +255,7 @@ fn test_search_by_id_not_found_right_direction() {
             random_membership_vector(),
             Box::new(lt.clone()),
             Box::new(NoopNetwork::new()),
-        );
+        ).expect("Failed to create BaseNode");
 
         let direction = Direction::Right;
         let req = IdentifierSearchRequest::new(target, lvl, direction);
@@ -289,7 +289,7 @@ fn test_search_by_id_exact_result() {
         random_membership_vector(),
         Box::new(lt.clone()),
         Box::new(NoopNetwork::new()),
-    );
+    ).expect("Failed to create BaseNode");
 
     // This test should ensure that when the exact target is found, it returns the correct level and identifier.
     for lvl in 0..LOOKUP_TABLE_LEVELS {
@@ -335,7 +335,7 @@ fn test_search_by_id_concurrent_found_left_direction() {
         random_membership_vector(),
         Box::new(lt.clone()),
         Box::new(NoopNetwork::new()),
-    );
+    ).expect("Failed to create BaseNode");
 
     // Ensure the target is not the same as the node's identifier
     assert_ne!(&target, node.get_identifier());
@@ -417,7 +417,7 @@ fn test_search_by_id_concurrent_right_direction() {
         random_membership_vector(),
         Box::new(lt.clone()),
         Box::new(NoopNetwork::new()),
-    );
+    ).expect("Failed to create BaseNode");
 
     // Ensure the target is not the same as the node's identifier
     assert_ne!(&target, node.get_identifier());
@@ -526,7 +526,7 @@ fn test_search_by_id_error_propagation() {
         random_membership_vector(),
         Box::new(MockErrorLookupTable),
         Box::new(NoopNetwork::new()),
-    );
+    ).expect("Failed to create BaseNode");
 
     // Create a random search request (any search request will return an error as
     // the mock lookup table is designed to fail)

--- a/src/node/search_by_id_test.rs
+++ b/src/node/search_by_id_test.rs
@@ -1,12 +1,20 @@
-use anyhow::anyhow;
-use std::sync::Arc;
-use rand::Rng;
 use super::base_node::BaseNode;
 use crate::core::model::direction::Direction;
-use crate::core::testutil::fixtures::{join_all_with_timeout, random_address, random_identifier, random_identifier_greater_than, random_identifier_less_than, random_lookup_table_with_extremes, random_membership_vector, span_fixture};
-use crate::core::{ArrayLookupTable, Identifier, IdentifierSearchRequest, LookupTable, LookupTableLevel, LOOKUP_TABLE_LEVELS};
 use crate::core::model::identity::Identity;
+use crate::core::testutil::fixtures::{
+    join_all_with_timeout, random_address, random_identifier, random_identifier_greater_than,
+    random_identifier_less_than, random_lookup_table_with_extremes, random_membership_vector,
+    span_fixture,
+};
+use crate::core::{
+    ArrayLookupTable, Identifier, IdentifierSearchRequest, LookupTable, LookupTableLevel,
+    LOOKUP_TABLE_LEVELS,
+};
+use crate::network::mock::noop_network::NoopNetwork;
 use crate::node::Node;
+use anyhow::anyhow;
+use rand::Rng;
+use std::sync::Arc;
 
 // TODO: move other tests from base_node.rs here
 /// Tests fallback behavior of `search_by_id` when no neighbors exist.
@@ -21,6 +29,7 @@ fn test_search_by_id_singleton_fallback() {
         id,
         mem_vec,
         Box::new(ArrayLookupTable::new(&span_fixture())),
+        Box::new(NoopNetwork::new()),
     );
 
     // Left and right searches for identifiers 5 and 15
@@ -61,9 +70,14 @@ fn test_search_by_id_found_left_direction() {
             0,
             Direction::Left,
         )
-            .expect("Failed to update entry in lookup table");
+        .expect("Failed to update entry in lookup table");
 
-        let node = BaseNode::new(random_identifier(), random_membership_vector(), Box::new(lt.clone()));
+        let node = BaseNode::new(
+            random_identifier(),
+            random_membership_vector(),
+            Box::new(lt.clone()),
+            Box::new(NoopNetwork::new()),
+        );
 
         let direction = Direction::Left;
         let req = IdentifierSearchRequest::new(target, lvl, direction);
@@ -104,13 +118,18 @@ fn test_search_by_id_found_right_direction() {
             0,
             Direction::Right,
         )
-            .expect("Failed to update entry in lookup table");
+        .expect("Failed to update entry in lookup table");
 
         let direction = Direction::Right;
         let req = IdentifierSearchRequest::new(target, lvl, direction);
 
-        let node = BaseNode::new(random_identifier(), random_membership_vector(), Box::new(lt.clone()));
-        
+        let node = BaseNode::new(
+            random_identifier(),
+            random_membership_vector(),
+            Box::new(lt.clone()),
+            Box::new(NoopNetwork::new()),
+        );
+
         let actual_result = node.search_by_id(&req).unwrap();
 
         let (expected_lvl, expected_identity) = lt
@@ -167,10 +186,15 @@ fn test_search_by_id_not_found_left_direction() {
                 lvl,
                 Direction::Left,
             )
-                .expect("Failed to update entry in lookup table");
+            .expect("Failed to update entry in lookup table");
         }
 
-        let node = BaseNode::new(random_identifier(), random_membership_vector(), Box::new(lt.clone()));
+        let node = BaseNode::new(
+            random_identifier(),
+            random_membership_vector(),
+            Box::new(lt.clone()),
+            Box::new(NoopNetwork::new()),
+        );
 
         let direction = Direction::Left;
         let req = IdentifierSearchRequest::new(target, lvl, direction);
@@ -223,10 +247,15 @@ fn test_search_by_id_not_found_right_direction() {
                 lvl,
                 Direction::Right,
             )
-                .expect("Failed to update entry in lookup table");
+            .expect("Failed to update entry in lookup table");
         }
 
-        let node = BaseNode::new(random_identifier(), random_membership_vector(), Box::new(lt.clone()));
+        let node = BaseNode::new(
+            random_identifier(),
+            random_membership_vector(),
+            Box::new(lt.clone()),
+            Box::new(NoopNetwork::new()),
+        );
 
         let direction = Direction::Right;
         let req = IdentifierSearchRequest::new(target, lvl, direction);
@@ -255,7 +284,12 @@ fn test_search_by_id_not_found_right_direction() {
 fn test_search_by_id_exact_result() {
     let lt = random_lookup_table_with_extremes(LOOKUP_TABLE_LEVELS);
 
-    let node = BaseNode::new(random_identifier(), random_membership_vector(), Box::new(lt.clone()));
+    let node = BaseNode::new(
+        random_identifier(),
+        random_membership_vector(),
+        Box::new(lt.clone()),
+        Box::new(NoopNetwork::new()),
+    );
 
     // This test should ensure that when the exact target is found, it returns the correct level and identifier.
     for lvl in 0..LOOKUP_TABLE_LEVELS {
@@ -296,8 +330,13 @@ fn test_search_by_id_concurrent_found_left_direction() {
     let lt = random_lookup_table_with_extremes(LOOKUP_TABLE_LEVELS);
     let target = random_identifier();
 
-    let node = BaseNode::new(random_identifier(), random_membership_vector(), Box::new(lt.clone()));
-    
+    let node = BaseNode::new(
+        random_identifier(),
+        random_membership_vector(),
+        Box::new(lt.clone()),
+        Box::new(NoopNetwork::new()),
+    );
+
     // Ensure the target is not the same as the node's identifier
     assert_ne!(&target, node.get_identifier());
 
@@ -373,7 +412,12 @@ fn test_search_by_id_concurrent_right_direction() {
     let lt = random_lookup_table_with_extremes(LOOKUP_TABLE_LEVELS);
     let target = random_identifier();
 
-    let node = BaseNode::new(random_identifier(), random_membership_vector(), Box::new(lt.clone()));
+    let node = BaseNode::new(
+        random_identifier(),
+        random_membership_vector(),
+        Box::new(lt.clone()),
+        Box::new(NoopNetwork::new()),
+    );
 
     // Ensure the target is not the same as the node's identifier
     assert_ne!(&target, node.get_identifier());
@@ -477,7 +521,12 @@ fn test_search_by_id_error_propagation() {
     }
 
     // Create a base node with the mock error lookup table
-    let node = BaseNode::new(random_identifier(), random_membership_vector(), Box::new(MockErrorLookupTable));
+    let node = BaseNode::new(
+        random_identifier(),
+        random_membership_vector(),
+        Box::new(MockErrorLookupTable),
+        Box::new(NoopNetwork::new()),
+    );
 
     // Create a random search request (any search request will return an error as
     // the mock lookup table is designed to fail)


### PR DESCRIPTION
This PR establishes the foundational networking capabilities for Skip Graph nodes by integrating the `Network` trait into `BaseNode` and providing essential testing infrastructure.

## Key Changes
### 🔧 Network Integration
  - Integrated `Network` trait into `BaseNode` constructor, requiring network dependency injection
  - Implemented `MessageProcessorCore` trait for BaseNode to handle incoming network messages
  - Added automatic message processor registration during node construction

###🧪 Testing Infrastructure
  - Introduced `NoopNetwork` - a no-operation network implementation for testing
  - Updated all BaseNode tests to use `NoopNetwork` instead of missing network dependency
  - Made network module publicly accessible (removed `#[cfg(test)]` restriction)

### ✨ API Improvements
  - Added Clone implementation for `Box<dyn Network>` using the `clone_box` pattern
  - Updated `BaseNode::new()` to return `Result<Self>` to handle network registration errors
  - Enhanced error handling for network processor registration

### Architecture Impact
This change moves `BaseNode` from a purely local/in-memory implementation toward a network-aware node that can participate in distributed Skip Graph operations. The integration follows the established patterns:
  - Shallow Cloning: `Network` instances are shallow-copyable with shared underlying state
  - Internal Thread Safety: `Network` implementations handle their own thread synchronization
  - Dependency Injection: `Nodes` require explicit network dependency, enabling testability

The `NoopNetwork` provides a clean testing boundary, allowing unit tests to focus on Skip Graph logic without network complexity.