### PR TITLE
chore: removes outdated TODO comment from search_by_id_test.rs

### DIFF
--- a/src/core/lookup/array_lookup_table_test.rs
+++ b/src/core/lookup/array_lookup_table_test.rs
@@ -204,7 +204,7 @@ mod tests {
                 barrier_ref.wait(); // wait for all threads to be ready
 
                 // Write the entry
-                lt_ref.update_entry(id.clone(), level, direction.clone()).unwrap();
+                lt_ref.update_entry(id.clone(), level, direction).unwrap();
 
                 // Read the entry back to check if it was written correctly
                 let entry = lt_ref.get_entry(level, direction).unwrap();
@@ -288,7 +288,7 @@ mod tests {
                     match op {
                         0 => {
                             let (table, last_writes) = &mut *shared_ref.lock();
-                            let read_val_opt = table.get_entry(level, direction.clone()).unwrap();
+                            let read_val_opt = table.get_entry(level, direction).unwrap();
 
                             let last_write_opt = last_writes.get(&(level, direction)).cloned();
 
@@ -318,7 +318,7 @@ mod tests {
                             let (table, last_writes) = &mut *shared_ref.lock();
 
                             let id = random_identity();
-                            if table.update_entry(id.clone(), level, direction.clone()).is_ok() {
+                            if table.update_entry(id.clone(), level, direction).is_ok() {
                                 // Update the last write map upon successful write
                                 last_writes.insert((level, direction), id);
                             }
@@ -326,7 +326,7 @@ mod tests {
                         2 => {
                             // remove atomically
                             let (table, last_writes) = &mut *shared_ref.lock();
-                            if table.remove_entry(level, direction.clone()).is_ok() {
+                            if table.remove_entry(level, direction).is_ok() {
                                 // Remove the last written entry
                                 last_writes.remove(&(level, direction));
                             }

--- a/src/core/lookup/array_lookup_table_test.rs
+++ b/src/core/lookup/array_lookup_table_test.rs
@@ -204,7 +204,7 @@ mod tests {
                 barrier_ref.wait(); // wait for all threads to be ready
 
                 // Write the entry
-                lt_ref.update_entry(id.clone(), level, direction).unwrap();
+                lt_ref.update_entry(id.clone(), level, direction.clone()).unwrap();
 
                 // Read the entry back to check if it was written correctly
                 let entry = lt_ref.get_entry(level, direction).unwrap();
@@ -288,7 +288,7 @@ mod tests {
                     match op {
                         0 => {
                             let (table, last_writes) = &mut *shared_ref.lock();
-                            let read_val_opt = table.get_entry(level, direction).unwrap();
+                            let read_val_opt = table.get_entry(level, direction.clone()).unwrap();
 
                             let last_write_opt = last_writes.get(&(level, direction)).cloned();
 
@@ -318,7 +318,7 @@ mod tests {
                             let (table, last_writes) = &mut *shared_ref.lock();
 
                             let id = random_identity();
-                            if table.update_entry(id.clone(), level, direction).is_ok() {
+                            if table.update_entry(id.clone(), level, direction.clone()).is_ok() {
                                 // Update the last write map upon successful write
                                 last_writes.insert((level, direction), id);
                             }
@@ -326,7 +326,7 @@ mod tests {
                         2 => {
                             // remove atomically
                             let (table, last_writes) = &mut *shared_ref.lock();
-                            if table.remove_entry(level, direction).is_ok() {
+                            if table.remove_entry(level, direction.clone()).is_ok() {
                                 // Remove the last written entry
                                 last_writes.remove(&(level, direction));
                             }

--- a/src/core/model/address.rs
+++ b/src/core/model/address.rs
@@ -1,7 +1,7 @@
 use fixedstr::{str128, str8};
 
 /// Represents a networking address; composed of host + port
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct Address {
     host: str128, // up to 128 bytes (on stack)
     port: str8,   // up to 8 bytes (on stack)

--- a/src/core/model/direction.rs
+++ b/src/core/model/direction.rs
@@ -1,5 +1,5 @@
 /// Represents the direction of search and lookup table access in SkipGraph.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub enum Direction {
     Left,
     Right,

--- a/src/core/model/direction.rs
+++ b/src/core/model/direction.rs
@@ -1,5 +1,5 @@
 /// Represents the direction of search and lookup table access in SkipGraph.
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub enum Direction {
     Left,
     Right,

--- a/src/core/model/direction.rs
+++ b/src/core/model/direction.rs
@@ -1,5 +1,5 @@
 /// Represents the direction of search and lookup table access in SkipGraph.
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 pub enum Direction {
     Left,
     Right,

--- a/src/core/model/identifier.rs
+++ b/src/core/model/identifier.rs
@@ -21,7 +21,7 @@ pub const MAX: Identifier = Identifier([255u8; IDENTIFIER_SIZE_BYTES]);
 /// - CompareGreater: the left identifier is greater than the right identifier.
 /// - CompareEqual: the two identifiers are equal.
 /// - CompareLess: the left identifier is less than the right identifier.
-#[derive(Debug, PartialEq, Clone, Copy)]
+#[derive(Debug, PartialEq, Clone)]
 pub enum ComparisonResult {
     CompareGreater,
     CompareEqual,
@@ -41,7 +41,7 @@ pub struct ComparisonContext {
 impl ComparisonContext {
     /// Returns the result of the comparison.
     pub fn result(&self) -> ComparisonResult {
-        self.result
+        self.result.clone()
     }
 
     /// Returns the left identifier.
@@ -84,7 +84,7 @@ impl Display for ComparisonContext {
 }
 
 // Identifier represents a 32-byte unique identifier for a Skip Graph node.
-#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct Identifier([u8; IDENTIFIER_SIZE_BYTES]);
 
 impl Identifier {
@@ -94,16 +94,16 @@ impl Identifier {
                 std::cmp::Ordering::Less => {
                     return ComparisonContext {
                         result: CompareLess,
-                        left: *self,
-                        right: *other,
+                        left: self.clone(),
+                        right: other.clone(),
                         diff_index: i,
                     };
                 }
                 std::cmp::Ordering::Greater => {
                     return ComparisonContext {
                         result: CompareGreater,
-                        left: *self,
-                        right: *other,
+                        left: self.clone(),
+                        right: other.clone(),
                         diff_index: i,
                     };
                 }
@@ -112,8 +112,8 @@ impl Identifier {
         }
         ComparisonContext {
             result: CompareEqual,
-            left: *self,
-            right: *other,
+            left: self.clone(),
+            right: other.clone(),
             diff_index: IDENTIFIER_SIZE_BYTES,
         }
     }

--- a/src/core/model/identifier.rs
+++ b/src/core/model/identifier.rs
@@ -21,7 +21,7 @@ pub const MAX: Identifier = Identifier([255u8; IDENTIFIER_SIZE_BYTES]);
 /// - CompareGreater: the left identifier is greater than the right identifier.
 /// - CompareEqual: the two identifiers are equal.
 /// - CompareLess: the left identifier is less than the right identifier.
-#[derive(Debug, PartialEq, Copy, Clone)]
+#[derive(Debug, PartialEq, Clone)]
 pub enum ComparisonResult {
     CompareGreater,
     CompareEqual,
@@ -31,7 +31,6 @@ pub enum ComparisonResult {
 /// ComparisonContext represents the context of a comparison between two identifiers.
 /// It contains the result of the comparison, the left and right identifiers, and the index of the differing byte.
 /// The differing byte is the first byte where the two identifiers differ.
-#[derive(Copy, Clone)]
 pub struct ComparisonContext {
     result: ComparisonResult,
     left: Identifier,
@@ -42,7 +41,7 @@ pub struct ComparisonContext {
 impl ComparisonContext {
     /// Returns the result of the comparison.
     pub fn result(&self) -> ComparisonResult {
-        self.result
+        self.result.clone()
     }
 
     /// Returns the left identifier.
@@ -85,7 +84,7 @@ impl Display for ComparisonContext {
 }
 
 // Identifier represents a 32-byte unique identifier for a Skip Graph node.
-#[derive(Copy, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct Identifier([u8; IDENTIFIER_SIZE_BYTES]);
 
 impl Identifier {
@@ -95,16 +94,16 @@ impl Identifier {
                 std::cmp::Ordering::Less => {
                     return ComparisonContext {
                         result: CompareLess,
-                        left: *self,
-                        right: *other,
+                        left: self.clone(),
+                        right: other.clone(),
                         diff_index: i,
                     };
                 }
                 std::cmp::Ordering::Greater => {
                     return ComparisonContext {
                         result: CompareGreater,
-                        left: *self,
-                        right: *other,
+                        left: self.clone(),
+                        right: other.clone(),
                         diff_index: i,
                     };
                 }
@@ -113,8 +112,8 @@ impl Identifier {
         }
         ComparisonContext {
             result: CompareEqual,
-            left: *self,
-            right: *other,
+            left: self.clone(),
+            right: other.clone(),
             diff_index: IDENTIFIER_SIZE_BYTES,
         }
     }

--- a/src/core/model/identifier.rs
+++ b/src/core/model/identifier.rs
@@ -21,7 +21,7 @@ pub const MAX: Identifier = Identifier([255u8; IDENTIFIER_SIZE_BYTES]);
 /// - CompareGreater: the left identifier is greater than the right identifier.
 /// - CompareEqual: the two identifiers are equal.
 /// - CompareLess: the left identifier is less than the right identifier.
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Copy, Clone)]
 pub enum ComparisonResult {
     CompareGreater,
     CompareEqual,
@@ -31,6 +31,7 @@ pub enum ComparisonResult {
 /// ComparisonContext represents the context of a comparison between two identifiers.
 /// It contains the result of the comparison, the left and right identifiers, and the index of the differing byte.
 /// The differing byte is the first byte where the two identifiers differ.
+#[derive(Copy, Clone)]
 pub struct ComparisonContext {
     result: ComparisonResult,
     left: Identifier,
@@ -41,7 +42,7 @@ pub struct ComparisonContext {
 impl ComparisonContext {
     /// Returns the result of the comparison.
     pub fn result(&self) -> ComparisonResult {
-        self.result.clone()
+        self.result
     }
 
     /// Returns the left identifier.
@@ -84,7 +85,7 @@ impl Display for ComparisonContext {
 }
 
 // Identifier represents a 32-byte unique identifier for a Skip Graph node.
-#[derive(Clone, PartialEq, Eq, Hash)]
+#[derive(Copy, Clone, PartialEq, Eq, Hash)]
 pub struct Identifier([u8; IDENTIFIER_SIZE_BYTES]);
 
 impl Identifier {
@@ -94,16 +95,16 @@ impl Identifier {
                 std::cmp::Ordering::Less => {
                     return ComparisonContext {
                         result: CompareLess,
-                        left: self.clone(),
-                        right: other.clone(),
+                        left: *self,
+                        right: *other,
                         diff_index: i,
                     };
                 }
                 std::cmp::Ordering::Greater => {
                     return ComparisonContext {
                         result: CompareGreater,
-                        left: self.clone(),
-                        right: other.clone(),
+                        left: *self,
+                        right: *other,
                         diff_index: i,
                     };
                 }
@@ -112,8 +113,8 @@ impl Identifier {
         }
         ComparisonContext {
             result: CompareEqual,
-            left: self.clone(),
-            right: other.clone(),
+            left: *self,
+            right: *other,
             diff_index: IDENTIFIER_SIZE_BYTES,
         }
     }

--- a/src/core/model/identity.rs
+++ b/src/core/model/identity.rs
@@ -12,8 +12,8 @@ impl Identity {
     /// Create a new Identity
     pub fn new(id: &Identifier, mem_vec: &MembershipVector, address: Address) -> Identity {
         Identity {
-            id: id.clone(),
-            mem_vec: mem_vec.clone(),
+            id: *id,
+            mem_vec: *mem_vec,
             address,
         }
     }

--- a/src/core/model/identity.rs
+++ b/src/core/model/identity.rs
@@ -12,8 +12,8 @@ impl Identity {
     /// Create a new Identity
     pub fn new(id: &Identifier, mem_vec: &MembershipVector, address: Address) -> Identity {
         Identity {
-            id: *id,
-            mem_vec: *mem_vec,
+            id: id.clone(),
+            mem_vec: mem_vec.clone(),
             address,
         }
     }

--- a/src/core/model/identity.rs
+++ b/src/core/model/identity.rs
@@ -12,8 +12,8 @@ impl Identity {
     /// Create a new Identity
     pub fn new(id: &Identifier, mem_vec: &MembershipVector, address: Address) -> Identity {
         Identity {
-            id: *id,
-            mem_vec: *mem_vec,
+            id: id.clone(),
+            mem_vec: mem_vec.clone(),
             address,
         }
     }
@@ -30,7 +30,7 @@ impl Identity {
 
     /// Get the address of the node
     pub fn address(&self) -> Address {
-        self.address
+        self.address.clone()
     }
 }
 
@@ -45,7 +45,7 @@ mod tests {
         let id = random_identifier();
         let mem_vec = random_membership_vector();
         let address = Address::new("localhost", "1234");
-        let identity = Identity::new(&id, &mem_vec, address);
+        let identity = Identity::new(&id, &mem_vec, address.clone());
         assert_eq!(identity.id(), &id);
         assert_eq!(identity.mem_vec(), &mem_vec);
         assert_eq!(identity.address(), address);

--- a/src/core/model/memvec.rs
+++ b/src/core/model/memvec.rs
@@ -3,7 +3,7 @@ use anyhow::{anyhow, Context};
 use std::fmt;
 use std::fmt::{Debug, Display, Formatter};
 
-#[derive(Copy, Clone, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq)]
 pub struct MembershipVector([u8; model::IDENTIFIER_SIZE_BYTES]);
 
 /// A struct representing a membership vector with a fixed size of 32 bytes.

--- a/src/core/model/memvec.rs
+++ b/src/core/model/memvec.rs
@@ -3,7 +3,7 @@ use anyhow::{anyhow, Context};
 use std::fmt;
 use std::fmt::{Debug, Display, Formatter};
 
-#[derive(Clone, PartialEq, Eq)]
+#[derive(Copy, Clone, PartialEq, Eq)]
 pub struct MembershipVector([u8; model::IDENTIFIER_SIZE_BYTES]);
 
 /// A struct representing a membership vector with a fixed size of 32 bytes.

--- a/src/core/model/memvec.rs
+++ b/src/core/model/memvec.rs
@@ -3,7 +3,7 @@ use anyhow::{anyhow, Context};
 use std::fmt;
 use std::fmt::{Debug, Display, Formatter};
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq)]
 pub struct MembershipVector([u8; model::IDENTIFIER_SIZE_BYTES]);
 
 /// A struct representing a membership vector with a fixed size of 32 bytes.

--- a/src/core/model/search.rs
+++ b/src/core/model/search.rs
@@ -2,7 +2,7 @@ use crate::core::lookup::LookupTableLevel;
 use crate::core::model::direction::Direction;
 use crate::core::Identifier;
 
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Clone)]
 pub struct IdSearchReq {
     pub target: Identifier,
     pub level: LookupTableLevel,
@@ -27,7 +27,7 @@ impl IdSearchReq {
     }
 
     pub fn direction(&self) -> Direction {
-        self.direction
+        self.direction.clone()
     }
 }
 
@@ -42,7 +42,7 @@ impl IdSearchReq {
 ///
 /// This struct derives the `Debug` trait, enabling it to be formatted using the `{:?}` formatter
 /// for debugging purposes.
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Clone)]
 pub struct IdSearchRes {
     target: Identifier,
     termination_level: LookupTableLevel,

--- a/src/core/model/search.rs
+++ b/src/core/model/search.rs
@@ -2,7 +2,7 @@ use crate::core::lookup::LookupTableLevel;
 use crate::core::model::direction::Direction;
 use crate::core::Identifier;
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
 pub struct IdSearchReq {
     pub target: Identifier,
     pub level: LookupTableLevel,
@@ -27,7 +27,7 @@ impl IdSearchReq {
     }
 
     pub fn direction(&self) -> Direction {
-        self.direction
+        self.direction.clone()
     }
 }
 
@@ -42,7 +42,7 @@ impl IdSearchReq {
 ///
 /// This struct derives the `Debug` trait, enabling it to be formatted using the `{:?}` formatter
 /// for debugging purposes.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
 pub struct IdSearchRes {
     target: Identifier,
     termination_level: LookupTableLevel,

--- a/src/core/model/search.rs
+++ b/src/core/model/search.rs
@@ -2,7 +2,7 @@ use crate::core::lookup::LookupTableLevel;
 use crate::core::model::direction::Direction;
 use crate::core::Identifier;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct IdSearchReq {
     pub target: Identifier,
     pub level: LookupTableLevel,
@@ -27,7 +27,7 @@ impl IdSearchReq {
     }
 
     pub fn direction(&self) -> Direction {
-        self.direction.clone()
+        self.direction
     }
 }
 
@@ -42,7 +42,7 @@ impl IdSearchReq {
 ///
 /// This struct derives the `Debug` trait, enabling it to be formatted using the `{:?}` formatter
 /// for debugging purposes.
-#[derive(Debug, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct IdSearchRes {
     target: Identifier,
     termination_level: LookupTableLevel,

--- a/src/network/mock/hub.rs
+++ b/src/network/mock/hub.rs
@@ -36,7 +36,7 @@ impl NetworkHub {
             ));
         }
 
-        let mock_network = Arc::new(MockNetwork::new(identifier.clone(), hub.clone()));
+        let mock_network = Arc::new(MockNetwork::new(identifier, hub.clone()));
         networks.insert(identifier, mock_network.clone());
         Ok(mock_network)
     }

--- a/src/network/mock/hub.rs
+++ b/src/network/mock/hub.rs
@@ -36,7 +36,7 @@ impl NetworkHub {
             ));
         }
 
-        let mock_network = Arc::new(MockNetwork::new(identifier, hub.clone()));
+        let mock_network = Arc::new(MockNetwork::new(identifier.clone(), hub.clone()));
         networks.insert(identifier, mock_network.clone());
         Ok(mock_network)
     }

--- a/src/network/mock/network.rs
+++ b/src/network/mock/network.rs
@@ -58,7 +58,7 @@ impl Clone for MockNetwork {
             core: RwLock::new(InnerMockNetwork {
                 hub: core_guard.hub.clone(),
                 processor: core_guard.processor.clone(), // Share processor state between clones
-                id: core_guard.id,
+                id: core_guard.id.clone(),
             }),
         }
     }
@@ -70,7 +70,7 @@ impl Network for MockNetwork {
         let core_guard = self.core.read();
         
         core_guard.hub
-            .route_event(core_guard.id, target_id, event)
+            .route_event(core_guard.id.clone(), target_id, event)
             .context("failed to route event")
     }
 

--- a/src/network/mock/network.rs
+++ b/src/network/mock/network.rs
@@ -58,7 +58,7 @@ impl Clone for MockNetwork {
             core: RwLock::new(InnerMockNetwork {
                 hub: core_guard.hub.clone(),
                 processor: core_guard.processor.clone(), // Share processor state between clones
-                id: core_guard.id.clone(),
+                id: core_guard.id,
             }),
         }
     }
@@ -70,7 +70,7 @@ impl Network for MockNetwork {
         let core_guard = self.core.read();
         
         core_guard.hub
-            .route_event(core_guard.id.clone(), target_id, event)
+            .route_event(core_guard.id, target_id, event)
             .context("failed to route event")
     }
 

--- a/src/network/mock/network_test.rs
+++ b/src/network/mock/network_test.rs
@@ -55,7 +55,7 @@ impl EventProcessorCore for MockEventProcessor {
 fn test_mock_event_processor() {
     let hub = NetworkHub::new();
     let target_id = random_identifier();
-    let mock_network = NetworkHub::new_mock_network(hub.clone(), target_id).unwrap();
+    let mock_network = NetworkHub::new_mock_network(hub.clone(), target_id.clone()).unwrap();
     let core_processor = MockEventProcessor::new();
     let processor = MessageProcessor::new(Box::new(core_processor.clone()));
     let event = TestMessage("Hello, World!".to_string());
@@ -78,7 +78,7 @@ fn test_hub_route_event() {
     let hub = NetworkHub::new();
 
     let id_1 = random_identifier();
-    let mock_net_1 = NetworkHub::new_mock_network(hub.clone(), id_1).unwrap();
+    let mock_net_1 = NetworkHub::new_mock_network(hub.clone(), id_1.clone()).unwrap();
     let core_proc_1 = MockEventProcessor::new();
     let msg_proc_1 = MessageProcessor::new(Box::new(core_proc_1.clone()));
     mock_net_1
@@ -106,7 +106,7 @@ fn test_network_hub_shallow_clone() {
     let target_id = random_identifier();
     
     // Create a mock network through the original hub
-    let mock_network = NetworkHub::new_mock_network(hub.clone(), target_id).unwrap();
+    let mock_network = NetworkHub::new_mock_network(hub.clone(), target_id.clone()).unwrap();
     
     // Create an event to route through the cloned hub
     let event = TestMessage("Shallow clone test".to_string());
@@ -135,7 +135,7 @@ fn test_concurrent_event_sending() {
     let hub = NetworkHub::new();
 
     let id_1 = random_identifier();
-    let mock_net_1 = NetworkHub::new_mock_network(hub.clone(), id_1).unwrap();
+    let mock_net_1 = NetworkHub::new_mock_network(hub.clone(), id_1.clone()).unwrap();
     let core_proc_1 = MockEventProcessor::new();
     let msg_proc_1 = MessageProcessor::new(Box::new(core_proc_1.clone()));
     mock_net_1
@@ -158,6 +158,7 @@ fn test_concurrent_event_sending() {
         let content = content.clone();
         let barrier_clone = barrier.clone();
         let mock_net_2_clone = mock_net_2.clone();
+        let id_1_clone = id_1.clone();
 
         let handle = thread::spawn(move || {
             let event = TestMessage(content);
@@ -166,7 +167,7 @@ fn test_concurrent_event_sending() {
             barrier_clone.wait();
 
             // Send the event
-            mock_net_2_clone.send_event(id_1, event).unwrap();
+            mock_net_2_clone.send_event(id_1_clone, event).unwrap();
         });
 
         handles.push(handle);
@@ -269,7 +270,7 @@ fn test_event_processor_clone_functionality() {
     
     // Process first event with first processor
     let  origin_id = random_identifier();
-    assert!(processor1.process_incoming_event(origin_id, event1).is_ok());
+    assert!(processor1.process_incoming_event(origin_id.clone(), event1).is_ok());
     assert!(core_processor.has_seen("Processor clone test 1"));
     
     // Process second event with cloned processor

--- a/src/network/mock/network_test.rs
+++ b/src/network/mock/network_test.rs
@@ -55,7 +55,7 @@ impl EventProcessorCore for MockEventProcessor {
 fn test_mock_event_processor() {
     let hub = NetworkHub::new();
     let target_id = random_identifier();
-    let mock_network = NetworkHub::new_mock_network(hub.clone(), target_id.clone()).unwrap();
+    let mock_network = NetworkHub::new_mock_network(hub.clone(), target_id).unwrap();
     let core_processor = MockEventProcessor::new();
     let processor = MessageProcessor::new(Box::new(core_processor.clone()));
     let event = TestMessage("Hello, World!".to_string());
@@ -78,7 +78,7 @@ fn test_hub_route_event() {
     let hub = NetworkHub::new();
 
     let id_1 = random_identifier();
-    let mock_net_1 = NetworkHub::new_mock_network(hub.clone(), id_1.clone()).unwrap();
+    let mock_net_1 = NetworkHub::new_mock_network(hub.clone(), id_1).unwrap();
     let core_proc_1 = MockEventProcessor::new();
     let msg_proc_1 = MessageProcessor::new(Box::new(core_proc_1.clone()));
     mock_net_1
@@ -106,7 +106,7 @@ fn test_network_hub_shallow_clone() {
     let target_id = random_identifier();
     
     // Create a mock network through the original hub
-    let mock_network = NetworkHub::new_mock_network(hub.clone(), target_id.clone()).unwrap();
+    let mock_network = NetworkHub::new_mock_network(hub.clone(), target_id).unwrap();
     
     // Create an event to route through the cloned hub
     let event = TestMessage("Shallow clone test".to_string());
@@ -135,7 +135,7 @@ fn test_concurrent_event_sending() {
     let hub = NetworkHub::new();
 
     let id_1 = random_identifier();
-    let mock_net_1 = NetworkHub::new_mock_network(hub.clone(), id_1.clone()).unwrap();
+    let mock_net_1 = NetworkHub::new_mock_network(hub.clone(), id_1).unwrap();
     let core_proc_1 = MockEventProcessor::new();
     let msg_proc_1 = MessageProcessor::new(Box::new(core_proc_1.clone()));
     mock_net_1
@@ -158,7 +158,7 @@ fn test_concurrent_event_sending() {
         let content = content.clone();
         let barrier_clone = barrier.clone();
         let mock_net_2_clone = mock_net_2.clone();
-        let id_1_clone = id_1.clone();
+        let id_1_clone = id_1;
 
         let handle = thread::spawn(move || {
             let event = TestMessage(content);
@@ -270,7 +270,7 @@ fn test_event_processor_clone_functionality() {
     
     // Process first event with first processor
     let  origin_id = random_identifier();
-    assert!(processor1.process_incoming_event(origin_id.clone(), event1).is_ok());
+    assert!(processor1.process_incoming_event(origin_id, event1).is_ok());
     assert!(core_processor.has_seen("Processor clone test 1"));
     
     // Process second event with cloned processor

--- a/src/network/mock/network_test.rs
+++ b/src/network/mock/network_test.rs
@@ -55,7 +55,7 @@ impl EventProcessorCore for MockEventProcessor {
 fn test_mock_event_processor() {
     let hub = NetworkHub::new();
     let target_id = random_identifier();
-    let mock_network = NetworkHub::new_mock_network(hub.clone(), target_id).unwrap();
+    let mock_network = NetworkHub::new_mock_network(hub.clone(), target_id.clone()).unwrap();
     let core_processor = MockEventProcessor::new();
     let processor = MessageProcessor::new(Box::new(core_processor.clone()));
     let event = TestMessage("Hello, World!".to_string());
@@ -78,7 +78,7 @@ fn test_hub_route_event() {
     let hub = NetworkHub::new();
 
     let id_1 = random_identifier();
-    let mock_net_1 = NetworkHub::new_mock_network(hub.clone(), id_1).unwrap();
+    let mock_net_1 = NetworkHub::new_mock_network(hub.clone(), id_1.clone()).unwrap();
     let core_proc_1 = MockEventProcessor::new();
     let msg_proc_1 = MessageProcessor::new(Box::new(core_proc_1.clone()));
     mock_net_1
@@ -106,7 +106,7 @@ fn test_network_hub_shallow_clone() {
     let target_id = random_identifier();
     
     // Create a mock network through the original hub
-    let mock_network = NetworkHub::new_mock_network(hub.clone(), target_id).unwrap();
+    let mock_network = NetworkHub::new_mock_network(hub.clone(), target_id.clone()).unwrap();
     
     // Create an event to route through the cloned hub
     let event = TestMessage("Shallow clone test".to_string());
@@ -135,7 +135,7 @@ fn test_concurrent_event_sending() {
     let hub = NetworkHub::new();
 
     let id_1 = random_identifier();
-    let mock_net_1 = NetworkHub::new_mock_network(hub.clone(), id_1).unwrap();
+    let mock_net_1 = NetworkHub::new_mock_network(hub.clone(), id_1.clone()).unwrap();
     let core_proc_1 = MockEventProcessor::new();
     let msg_proc_1 = MessageProcessor::new(Box::new(core_proc_1.clone()));
     mock_net_1
@@ -158,7 +158,7 @@ fn test_concurrent_event_sending() {
         let content = content.clone();
         let barrier_clone = barrier.clone();
         let mock_net_2_clone = mock_net_2.clone();
-        let id_1_clone = id_1;
+        let id_1_clone = id_1.clone();
 
         let handle = thread::spawn(move || {
             let event = TestMessage(content);
@@ -270,7 +270,7 @@ fn test_event_processor_clone_functionality() {
     
     // Process first event with first processor
     let  origin_id = random_identifier();
-    assert!(processor1.process_incoming_event(origin_id, event1).is_ok());
+    assert!(processor1.process_incoming_event(origin_id.clone(), event1).is_ok());
     assert!(core_processor.has_seen("Processor clone test 1"));
     
     // Process second event with cloned processor

--- a/src/node/base_node.rs
+++ b/src/node/base_node.rs
@@ -93,7 +93,7 @@ impl Node for BaseNode {
         // Collect neighbors from levels <= req.level in req.direction
         let candidates: Result<Vec<_>, _> = (0..=req.level())
             .filter_map(|lvl| match self.lt.get_entry(lvl, req.direction()) {
-                Ok(Some(identity)) => Some(Ok((*identity.id(), lvl))),
+                Ok(Some(identity)) => Some(Ok((identity.id().clone(), lvl))),
                 Ok(None) => None,
                 Err(e) => Some(Err(anyhow!(
                     "error while searching by id in level {}: {}",
@@ -118,21 +118,21 @@ impl Node for BaseNode {
                 candidates
                     .into_iter()
                     .filter(|(id, _)| id >= req.target())
-                    .min_by_key(|(id, _)| *id)
+                    .min_by_key(|(id, _)| id.clone())
             }
             Direction::Right => {
                 // In the right direction, the result is the greatest identifier that is less than or equal to the target
                 candidates
                     .into_iter()
                     .filter(|(id, _)| id <= req.target())
-                    .max_by_key(|(id, _)| *id)
+                    .max_by_key(|(id, _)| id.clone())
             }
         };
 
         match result {
             Some((id, level)) => {
                 // If a candidate is found, return it
-                let search_result = IdSearchRes::new(*req.target(), level, id);
+                let search_result = IdSearchRes::new(req.target().clone(), level, id.clone());
                 tracing::trace!(
                     "search successful: found match {:?} at level {}",
                     id,
@@ -150,9 +150,9 @@ impl Node for BaseNode {
                     self.get_identifier()
                 );
                 Ok(IdSearchRes::new(
-                    *req.target(),
+                    req.target().clone(),
                     0,
-                    *self.get_identifier(),
+                    self.get_identifier().clone(),
                 ))
             }
         }
@@ -185,7 +185,7 @@ impl EventProcessorCore for BaseNode {
                 );
 
                 let res = self.search_by_id(&req).map_err(|e| anyhow!("failed to perform search by id {}", e))?;
-                let response_event = IdSearchResponse(res);
+                let response_event = IdSearchResponse(res.clone());
 
                 tracing::trace!(
                     "sending IdSearchResponse with result {:?} at level {}",
@@ -238,8 +238,8 @@ impl BaseNode {
         );
 
         let node = BaseNode {
-            id,
-            mem_vec,
+            id: id.clone(),
+            mem_vec: mem_vec.clone(),
             lt,
             net,
             span: span.clone(),
@@ -288,8 +288,8 @@ impl fmt::Debug for BaseNode {
 impl Clone for BaseNode {
     fn clone(&self) -> Self {
         BaseNode {
-            id: self.id,
-            mem_vec: self.mem_vec,
+            id: self.id.clone(),
+            mem_vec: self.mem_vec.clone(),
             lt: self.lt.clone(),
             net: self.net.clone(),
             span: self.span.clone(),
@@ -311,8 +311,8 @@ mod tests {
         let id = random_identifier();
         let mem_vec = random_membership_vector();
         let node = BaseNode {
-            id,
-            mem_vec,
+            id: id.clone(),
+            mem_vec: mem_vec.clone(),
             lt: Box::new(ArrayLookupTable::new(&span_fixture())),
             net: Box::new(Unimock::new(())), // No expectations needed for direct struct construction
             span: span_fixture(),

--- a/src/node/search_by_id_test.rs
+++ b/src/node/search_by_id_test.rs
@@ -35,7 +35,7 @@ fn test_search_by_id_singleton_fallback() {
     ));
     let node = BaseNode::new(
         span_fixture(),
-        id.clone(),
+        id,
         mem_vec,
         Box::new(ArrayLookupTable::new(&span_fixture())),
         Box::new(mock_net),
@@ -51,7 +51,7 @@ fn test_search_by_id_singleton_fallback() {
     ];
 
     for (target, direction) in cases {
-        let req = IdSearchReq::new(target.clone(), 3, direction);
+        let req = IdSearchReq::new(target, 3, direction);
         let res = node.search_by_id(&req).expect("search failed");
         // Ensures the search is terminated at the level zero.
         assert_eq!(res.termination_level(), 0);
@@ -101,7 +101,7 @@ fn test_search_by_id_found_left_direction() {
         .expect("failed to create BaseNode");
 
         let direction = Direction::Left;
-        let req = IdSearchReq::new(target.clone(), lvl, direction);
+        let req = IdSearchReq::new(target, lvl, direction);
 
         let actual_result = node.search_by_id(&req).unwrap();
 
@@ -110,7 +110,7 @@ fn test_search_by_id_found_left_direction() {
             .unwrap()
             .into_iter()
             .filter(|(l, id)| *l <= req.level() && id.id() >= req.target())
-            .min_by_key(|(_, id)| id.id().clone())
+            .min_by_key(|(_, id)| *id.id())
             .unwrap();
 
         assert_eq!(expected_lvl, actual_result.termination_level());
@@ -142,7 +142,7 @@ fn test_search_by_id_found_right_direction() {
         .expect("failed to update entry in lookup table");
 
         let direction = Direction::Right;
-        let req = IdSearchReq::new(target.clone(), lvl, direction);
+        let req = IdSearchReq::new(target, lvl, direction);
 
         let mock_net = Unimock::new((
             NetworkMock::register_processor
@@ -169,7 +169,7 @@ fn test_search_by_id_found_right_direction() {
             .unwrap()
             .into_iter()
             .filter(|(lvl, id)| *lvl <= req.level() && id.id() <= req.target())
-            .max_by_key(|(_, id)| id.id().clone())
+            .max_by_key(|(_, id)| *id.id())
             .unwrap();
 
         assert_eq!(expected_lvl, actual_result.termination_level());
@@ -240,7 +240,7 @@ fn test_search_by_id_not_found_left_direction() {
         .expect("failed to create BaseNode");
 
         let direction = Direction::Left;
-        let req = IdSearchReq::new(target.clone(), lvl, direction);
+        let req = IdSearchReq::new(target, lvl, direction);
 
         let actual_result = node.search_by_id(&req).unwrap();
 
@@ -312,7 +312,7 @@ fn test_search_by_id_not_found_right_direction() {
         .expect("failed to create BaseNode");
 
         let direction = Direction::Right;
-        let req = IdSearchReq::new(target.clone(), lvl, direction);
+        let req = IdSearchReq::new(target, lvl, direction);
 
         let actual_result = node.search_by_id(&req).unwrap();
 
@@ -359,9 +359,9 @@ fn test_search_by_id_exact_result() {
     // This test should ensure that when the exact target is found, it returns the correct level and identifier.
     for lvl in 0..LOOKUP_TABLE_LEVELS {
         for direction in [Direction::Left, Direction::Right] {
-            let target_identity = lt.get_entry(lvl, direction.clone()).unwrap().unwrap();
+            let target_identity = lt.get_entry(lvl, direction).unwrap().unwrap();
             let target = target_identity.id();
-            let req = IdSearchReq::new(target.clone(), lvl, direction);
+            let req = IdSearchReq::new(*target, lvl, direction);
 
             let actual_result = node.search_by_id(&req).unwrap();
 
@@ -425,7 +425,7 @@ fn test_search_by_id_concurrent_found_left_direction() {
         let handle_barrier = barrier.clone();
         let node_ref = node.clone();
         let lt_clone = lt.clone();
-        let target_clone = target.clone();
+        let target_clone = target;
         let handle = std::thread::spawn(move || {
             // Wait for all threads to be ready
             handle_barrier.wait();
@@ -434,7 +434,7 @@ fn test_search_by_id_concurrent_found_left_direction() {
             let lvl = rand::rng().random_range(0..LOOKUP_TABLE_LEVELS);
 
             // Perform the search in the left direction
-            let req = IdSearchReq::new(target_clone.clone(), lvl, Direction::Left);
+            let req = IdSearchReq::new(target_clone, lvl, Direction::Left);
             let actual_result = node_ref.search_by_id(&req).unwrap();
 
             let expected_result = lt_clone
@@ -442,7 +442,7 @@ fn test_search_by_id_concurrent_found_left_direction() {
                 .unwrap()
                 .into_iter()
                 .filter(|(l, id)| *l <= req.level() && id.id() >= req.target())
-                .min_by_key(|(_, id)| id.id().clone());
+                .min_by_key(|(_, id)| *id.id());
 
             match expected_result {
                 Some((expected_lvl, expected_identity)) => {
@@ -519,7 +519,7 @@ fn test_search_by_id_concurrent_right_direction() {
         let handle_barrier = barrier.clone();
         let node_ref = node.clone();
         let lt_clone = lt.clone();
-        let target_clone = target.clone();
+        let target_clone = target;
         let handle = std::thread::spawn(move || {
             // Wait for all threads to be ready
             handle_barrier.wait();
@@ -528,7 +528,7 @@ fn test_search_by_id_concurrent_right_direction() {
             let lvl = rand::rng().random_range(0..LOOKUP_TABLE_LEVELS);
 
             // Perform the search in the right direction
-            let req = IdSearchReq::new(target_clone.clone(), lvl, Direction::Right);
+            let req = IdSearchReq::new(target_clone, lvl, Direction::Right);
             let actual_result = node_ref.search_by_id(&req).unwrap();
 
             let expected_result = lt_clone
@@ -536,7 +536,7 @@ fn test_search_by_id_concurrent_right_direction() {
                 .unwrap()
                 .into_iter()
                 .filter(|(l, id)| *l <= req.level() && id.id() <= req.target())
-                .max_by_key(|(_, id)| id.id().clone());
+                .max_by_key(|(_, id)| *id.id());
 
             match expected_result {
                 Some((expected_lvl, expected_identity)) => {
@@ -685,8 +685,8 @@ fn test_search_by_id_networking_integration() {
     let node_id = random_identifier();
 
     // Create the search request event
-    let search_request = IdSearchReq::new(target.clone(), 0, Direction::Left);
-    let request_event = Event::IdSearchRequest(search_request.clone());
+    let search_request = IdSearchReq::new(target, 0, Direction::Left);
+    let request_event = Event::IdSearchRequest(search_request);
     
     // Mock the network to capture sent events
     let sent_events = Arc::new(Mutex::new(Vec::new()));
@@ -738,7 +738,7 @@ fn test_search_by_id_networking_integration() {
                 .filter(|(l, id)| {
                     *l <= search_request.level() && id.id() >= search_request.target()
                 })
-                .min_by_key(|(_, id)| id.id().clone())
+                .min_by_key(|(_, id)| *id.id())
                 .unwrap();
 
             assert_eq!(

--- a/src/node/search_by_id_test.rs
+++ b/src/node/search_by_id_test.rs
@@ -17,7 +17,6 @@ use rand::Rng;
 use std::sync::{Arc, Mutex};
 use unimock::*;
 
-// TODO: move other tests from base_node.rs here
 /// Tests fallback behavior of `search_by_id` when no neighbors exist.
 /// Each case mirrors a search on a singleton node as described in the behavior
 /// matrix of issue https://github.com/thep2p/skipgraph-rust/issues/22.

--- a/src/node/search_by_id_test.rs
+++ b/src/node/search_by_id_test.rs
@@ -35,7 +35,7 @@ fn test_search_by_id_singleton_fallback() {
     ));
     let node = BaseNode::new(
         span_fixture(),
-        id,
+        id.clone(),
         mem_vec,
         Box::new(ArrayLookupTable::new(&span_fixture())),
         Box::new(mock_net),
@@ -51,7 +51,7 @@ fn test_search_by_id_singleton_fallback() {
     ];
 
     for (target, direction) in cases {
-        let req = IdSearchReq::new(target, 3, direction);
+        let req = IdSearchReq::new(target.clone(), 3, direction);
         let res = node.search_by_id(&req).expect("search failed");
         // Ensures the search is terminated at the level zero.
         assert_eq!(res.termination_level(), 0);
@@ -101,7 +101,7 @@ fn test_search_by_id_found_left_direction() {
         .expect("failed to create BaseNode");
 
         let direction = Direction::Left;
-        let req = IdSearchReq::new(target, lvl, direction);
+        let req = IdSearchReq::new(target.clone(), lvl, direction);
 
         let actual_result = node.search_by_id(&req).unwrap();
 
@@ -110,7 +110,7 @@ fn test_search_by_id_found_left_direction() {
             .unwrap()
             .into_iter()
             .filter(|(l, id)| *l <= req.level() && id.id() >= req.target())
-            .min_by_key(|(_, id)| *id.id())
+            .min_by_key(|(_, id)| id.id().clone())
             .unwrap();
 
         assert_eq!(expected_lvl, actual_result.termination_level());
@@ -142,7 +142,7 @@ fn test_search_by_id_found_right_direction() {
         .expect("failed to update entry in lookup table");
 
         let direction = Direction::Right;
-        let req = IdSearchReq::new(target, lvl, direction);
+        let req = IdSearchReq::new(target.clone(), lvl, direction);
 
         let mock_net = Unimock::new((
             NetworkMock::register_processor
@@ -169,7 +169,7 @@ fn test_search_by_id_found_right_direction() {
             .unwrap()
             .into_iter()
             .filter(|(lvl, id)| *lvl <= req.level() && id.id() <= req.target())
-            .max_by_key(|(_, id)| *id.id())
+            .max_by_key(|(_, id)| id.id().clone())
             .unwrap();
 
         assert_eq!(expected_lvl, actual_result.termination_level());
@@ -240,7 +240,7 @@ fn test_search_by_id_not_found_left_direction() {
         .expect("failed to create BaseNode");
 
         let direction = Direction::Left;
-        let req = IdSearchReq::new(target, lvl, direction);
+        let req = IdSearchReq::new(target.clone(), lvl, direction);
 
         let actual_result = node.search_by_id(&req).unwrap();
 
@@ -312,7 +312,7 @@ fn test_search_by_id_not_found_right_direction() {
         .expect("failed to create BaseNode");
 
         let direction = Direction::Right;
-        let req = IdSearchReq::new(target, lvl, direction);
+        let req = IdSearchReq::new(target.clone(), lvl, direction);
 
         let actual_result = node.search_by_id(&req).unwrap();
 
@@ -359,9 +359,9 @@ fn test_search_by_id_exact_result() {
     // This test should ensure that when the exact target is found, it returns the correct level and identifier.
     for lvl in 0..LOOKUP_TABLE_LEVELS {
         for direction in [Direction::Left, Direction::Right] {
-            let target_identity = lt.get_entry(lvl, direction).unwrap().unwrap();
+            let target_identity = lt.get_entry(lvl, direction.clone()).unwrap().unwrap();
             let target = target_identity.id();
-            let req = IdSearchReq::new(*target, lvl, direction);
+            let req = IdSearchReq::new(target.clone(), lvl, direction);
 
             let actual_result = node.search_by_id(&req).unwrap();
 
@@ -425,7 +425,7 @@ fn test_search_by_id_concurrent_found_left_direction() {
         let handle_barrier = barrier.clone();
         let node_ref = node.clone();
         let lt_clone = lt.clone();
-        let target_clone = target;
+        let target_clone = target.clone();
         let handle = std::thread::spawn(move || {
             // Wait for all threads to be ready
             handle_barrier.wait();
@@ -434,7 +434,7 @@ fn test_search_by_id_concurrent_found_left_direction() {
             let lvl = rand::rng().random_range(0..LOOKUP_TABLE_LEVELS);
 
             // Perform the search in the left direction
-            let req = IdSearchReq::new(target_clone, lvl, Direction::Left);
+            let req = IdSearchReq::new(target_clone.clone(), lvl, Direction::Left);
             let actual_result = node_ref.search_by_id(&req).unwrap();
 
             let expected_result = lt_clone
@@ -442,7 +442,7 @@ fn test_search_by_id_concurrent_found_left_direction() {
                 .unwrap()
                 .into_iter()
                 .filter(|(l, id)| *l <= req.level() && id.id() >= req.target())
-                .min_by_key(|(_, id)| *id.id());
+                .min_by_key(|(_, id)| id.id().clone());
 
             match expected_result {
                 Some((expected_lvl, expected_identity)) => {
@@ -519,7 +519,7 @@ fn test_search_by_id_concurrent_right_direction() {
         let handle_barrier = barrier.clone();
         let node_ref = node.clone();
         let lt_clone = lt.clone();
-        let target_clone = target;
+        let target_clone = target.clone();
         let handle = std::thread::spawn(move || {
             // Wait for all threads to be ready
             handle_barrier.wait();
@@ -528,7 +528,7 @@ fn test_search_by_id_concurrent_right_direction() {
             let lvl = rand::rng().random_range(0..LOOKUP_TABLE_LEVELS);
 
             // Perform the search in the right direction
-            let req = IdSearchReq::new(target_clone, lvl, Direction::Right);
+            let req = IdSearchReq::new(target_clone.clone(), lvl, Direction::Right);
             let actual_result = node_ref.search_by_id(&req).unwrap();
 
             let expected_result = lt_clone
@@ -536,7 +536,7 @@ fn test_search_by_id_concurrent_right_direction() {
                 .unwrap()
                 .into_iter()
                 .filter(|(l, id)| *l <= req.level() && id.id() <= req.target())
-                .max_by_key(|(_, id)| *id.id());
+                .max_by_key(|(_, id)| id.id().clone());
 
             match expected_result {
                 Some((expected_lvl, expected_identity)) => {
@@ -685,8 +685,8 @@ fn test_search_by_id_networking_integration() {
     let node_id = random_identifier();
 
     // Create the search request event
-    let search_request = IdSearchReq::new(target, 0, Direction::Left);
-    let request_event = Event::IdSearchRequest(search_request);
+    let search_request = IdSearchReq::new(target.clone(), 0, Direction::Left);
+    let request_event = Event::IdSearchRequest(search_request.clone());
     
     // Mock the network to capture sent events
     let sent_events = Arc::new(Mutex::new(Vec::new()));
@@ -738,7 +738,7 @@ fn test_search_by_id_networking_integration() {
                 .filter(|(l, id)| {
                     *l <= search_request.level() && id.id() >= search_request.target()
                 })
-                .min_by_key(|(_, id)| *id.id())
+                .min_by_key(|(_, id)| id.id().clone())
                 .unwrap();
 
             assert_eq!(


### PR DESCRIPTION
# Summary

  Remove outdated TODO comment from search_by_id_test.rs

 # Details

  The TODO comment "move other tests from base_node.rs here" was outdated since:
  - All relevant search_by_id tests are already properly organized in search_by_id_test.rs (12 comprehensive test cases)
  - The only remaining test in base_node.rs (test_base_node) is appropriately placed there as it tests basic constructor/getter functionality, not search behavior.

