### PR TITLE
[Rust] Upgrades version of Rust to 1.89.0

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.88.0 # Specify the Rust version
+          toolchain: 1.89.0 # Specify the Rust version
           override: true
       - name: Build
         run: cargo build --verbose
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.88.0 # Specify the Rust version
+          toolchain: 1.89.0 # Specify the Rust version
           override: true
       - name: Install Tools
         run: make install-tools

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "skipgraph"
 version = "0.1.0"
 edition = "2021"
-rust-version = "1.88.0"
+rust-version = "1.89.0"
 
 [dependencies]
 hex = "0.4.3"

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ overlay or distributed key-value store.
 To use or contribute to this project, you need to have the following installed:
 
 - **Rust**: Ensure you have Rust installed. You can download it from [Rust's official website](https://rust-lang.org/). The minimum required
-  version is `rustc 1.88.0 (6b00bc388 2025-06-23)`.
+  version is `rustc 1.89.0 (29483883e 2025-08-04)`.
 - **Cargo**: Cargo is the Rust package manager and is included with the Rust installation. The minimum required version is `cargo 1.88.0 (873a06493 2025-05-10)`.
   .
 


### PR DESCRIPTION
This pull request updates the minimum required Rust version for the project from 1.88.0 to 1.89.0. The change is reflected in the CI workflow, documentation, and project configuration to ensure consistency.

Rust version upgrade:

* Updated the `toolchain` version from `1.88.0` to `1.89.0` in the GitHub Actions workflow for both build and tool installation steps in `.github/workflows/rust.yml`. [[1]](diffhunk://#diff-73e17259d77e5fbef83b2bdbbe4dc40a912f807472287f7f45b77e0cbf78792dL19-R19) [[2]](diffhunk://#diff-73e17259d77e5fbef83b2bdbbe4dc40a912f807472287f7f45b77e0cbf78792dL32-R32)
* Changed the `rust-version` field in `Cargo.toml` to require Rust 1.89.0.
* Updated the minimum required Rust version in the installation instructions in `README.md` to 1.89.0.