### PR TITLE
feat: deprecates `Clone` for fixed-size `Copy`  types

### DIFF
--- a/src/core/lookup/array_lookup_table.rs
+++ b/src/core/lookup/array_lookup_table.rs
@@ -79,10 +79,10 @@ impl LookupTable for ArrayLookupTable {
 
         match direction {
             Direction::Left => {
-                inner.left[level] = Some(identity.clone());
+                inner.left[level] = Some(identity);
             }
             Direction::Right => {
-                inner.right[level] = Some(identity.clone());
+                inner.right[level] = Some(identity);
             }
         }
 
@@ -110,8 +110,8 @@ impl LookupTable for ArrayLookupTable {
 
         // Record the current entry before removing it for logging
         let current_entry = match direction {
-            Direction::Left => inner.left[level].clone(),
-            Direction::Right => inner.right[level].clone(),
+            Direction::Left => inner.left[level],
+            Direction::Right => inner.right[level],
         };
 
         match direction {
@@ -153,8 +153,8 @@ impl LookupTable for ArrayLookupTable {
         let inner = self.inner.read();
 
         let entry = match direction {
-            Direction::Left => inner.left[level].clone(),
-            Direction::Right => inner.right[level].clone(),
+            Direction::Left => inner.left[level],
+            Direction::Right => inner.right[level],
         };
 
         // Log the get operation
@@ -205,7 +205,7 @@ impl LookupTable for ArrayLookupTable {
         let mut neighbors = Vec::new();
         for (level, entry) in inner.left.iter().enumerate() {
             if let Some(identity) = entry {
-                neighbors.push((level, identity.clone()));
+                neighbors.push((level, *identity));
             }
         }
         Ok(neighbors)
@@ -218,7 +218,7 @@ impl LookupTable for ArrayLookupTable {
         let mut neighbors = Vec::new();
         for (level, entry) in inner.right.iter().enumerate() {
             if let Some(identity) = entry {
-                neighbors.push((level, identity.clone()));
+                neighbors.push((level, *identity));
             }
         }
         Ok(neighbors)

--- a/src/core/model/address.rs
+++ b/src/core/model/address.rs
@@ -1,7 +1,7 @@
 use fixedstr::{str128, str8};
 
 /// Represents a networking address; composed of host + port
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq)]
 pub struct Address {
     host: str128, // up to 128 bytes (on stack)
     port: str8,   // up to 8 bytes (on stack)

--- a/src/core/model/address.rs
+++ b/src/core/model/address.rs
@@ -1,10 +1,18 @@
 use fixedstr::{str128, str8};
 
 /// Represents a networking address; composed of host + port
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Debug, PartialEq)]
 pub struct Address {
     host: str128, // up to 128 bytes (on stack)
     port: str8,   // up to 8 bytes (on stack)
+}
+
+#[allow(useless_deprecated)]
+impl Clone for Address {
+    #[deprecated(note = "This type is Copy; prefer implicit copying instead of .clone()")]
+    fn clone(&self) -> Self {
+        *self
+    }
 }
 
 impl Address {

--- a/src/core/model/direction.rs
+++ b/src/core/model/direction.rs
@@ -1,6 +1,14 @@
 /// Represents the direction of search and lookup table access in SkipGraph.
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Copy, Debug, PartialEq, Eq, Hash)]
 pub enum Direction {
     Left,
     Right,
+}
+
+#[allow(useless_deprecated)]
+impl Clone for Direction {
+    #[deprecated(note = "This type is Copy; prefer implicit copying instead of .clone()")]
+    fn clone(&self) -> Self {
+        *self
+    }
 }

--- a/src/core/model/direction.rs
+++ b/src/core/model/direction.rs
@@ -1,5 +1,5 @@
 /// Represents the direction of search and lookup table access in SkipGraph.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 pub enum Direction {
     Left,
     Right,

--- a/src/core/model/identifier.rs
+++ b/src/core/model/identifier.rs
@@ -21,7 +21,7 @@ pub const MAX: Identifier = Identifier([255u8; IDENTIFIER_SIZE_BYTES]);
 /// - CompareGreater: the left identifier is greater than the right identifier.
 /// - CompareEqual: the two identifiers are equal.
 /// - CompareLess: the left identifier is less than the right identifier.
-#[derive(Debug, PartialEq, Clone, Copy)]
+#[derive(Debug, PartialEq, Copy, Clone)]
 pub enum ComparisonResult {
     CompareGreater,
     CompareEqual,
@@ -31,6 +31,7 @@ pub enum ComparisonResult {
 /// ComparisonContext represents the context of a comparison between two identifiers.
 /// It contains the result of the comparison, the left and right identifiers, and the index of the differing byte.
 /// The differing byte is the first byte where the two identifiers differ.
+#[derive(Copy, Clone)]
 pub struct ComparisonContext {
     result: ComparisonResult,
     left: Identifier,
@@ -84,7 +85,7 @@ impl Display for ComparisonContext {
 }
 
 // Identifier represents a 32-byte unique identifier for a Skip Graph node.
-#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Copy, Clone, PartialEq, Eq, Hash)]
 pub struct Identifier([u8; IDENTIFIER_SIZE_BYTES]);
 
 impl Identifier {

--- a/src/core/model/identifier.rs
+++ b/src/core/model/identifier.rs
@@ -21,17 +21,25 @@ pub const MAX: Identifier = Identifier([255u8; IDENTIFIER_SIZE_BYTES]);
 /// - CompareGreater: the left identifier is greater than the right identifier.
 /// - CompareEqual: the two identifiers are equal.
 /// - CompareLess: the left identifier is less than the right identifier.
-#[derive(Debug, PartialEq, Copy, Clone)]
+#[derive(Debug, PartialEq, Copy)]
 pub enum ComparisonResult {
     CompareGreater,
     CompareEqual,
     CompareLess,
 }
 
+#[allow(useless_deprecated)]
+impl Clone for ComparisonResult {
+    #[deprecated(note = "This type is Copy; prefer implicit copying instead of .clone()")]
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
 /// ComparisonContext represents the context of a comparison between two identifiers.
 /// It contains the result of the comparison, the left and right identifiers, and the index of the differing byte.
 /// The differing byte is the first byte where the two identifiers differ.
-#[derive(Copy, Clone)]
+#[derive(Copy)]
 pub struct ComparisonContext {
     result: ComparisonResult,
     left: Identifier,
@@ -61,6 +69,14 @@ impl ComparisonContext {
     }
 }
 
+#[allow(useless_deprecated)]
+impl Clone for ComparisonContext {
+    #[deprecated(note = "This type is Copy; prefer implicit copying instead of .clone()")]
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
 /// Display overloads the Display trait for ComparisonContext, allowing it to be printed upon a call to format! or to_string().
 impl Display for ComparisonContext {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
@@ -85,8 +101,16 @@ impl Display for ComparisonContext {
 }
 
 // Identifier represents a 32-byte unique identifier for a Skip Graph node.
-#[derive(Copy, Clone, PartialEq, Eq, Hash)]
+#[derive(Copy, PartialEq, Eq, Hash)]
 pub struct Identifier([u8; IDENTIFIER_SIZE_BYTES]);
+
+#[allow(useless_deprecated)]
+impl Clone for Identifier {
+    #[deprecated(note = "This type is Copy; prefer implicit copying instead of .clone()")]
+    fn clone(&self) -> Self {
+        *self
+    }
+}
 
 impl Identifier {
     pub fn compare(&self, other: &Identifier) -> ComparisonContext {

--- a/src/core/model/identity.rs
+++ b/src/core/model/identity.rs
@@ -1,7 +1,7 @@
 use crate::core::{Address, Identifier, MembershipVector};
 
 /// Identity is an immutable struct that represents a node's identity in the network (ID, MembershipVector, Address).
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq)]
 pub struct Identity {
     id: Identifier,
     mem_vec: MembershipVector,

--- a/src/core/model/identity.rs
+++ b/src/core/model/identity.rs
@@ -1,11 +1,19 @@
 use crate::core::{Address, Identifier, MembershipVector};
 
 /// Identity is an immutable struct that represents a node's identity in the network (ID, MembershipVector, Address).
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Debug, PartialEq)]
 pub struct Identity {
     id: Identifier,
     mem_vec: MembershipVector,
     address: Address, // network address of the node
+}
+
+#[allow(useless_deprecated)]
+impl Clone for Identity {
+    #[deprecated(note = "This type is Copy; prefer implicit copying instead of .clone()")]
+    fn clone(&self) -> Self {
+        *self
+    }
 }
 
 impl Identity {

--- a/src/core/model/memvec.rs
+++ b/src/core/model/memvec.rs
@@ -3,7 +3,7 @@ use anyhow::{anyhow, Context};
 use std::fmt;
 use std::fmt::{Debug, Display, Formatter};
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Copy, Clone, PartialEq, Eq)]
 pub struct MembershipVector([u8; model::IDENTIFIER_SIZE_BYTES]);
 
 /// A struct representing a membership vector with a fixed size of 32 bytes.

--- a/src/core/model/memvec.rs
+++ b/src/core/model/memvec.rs
@@ -3,8 +3,16 @@ use anyhow::{anyhow, Context};
 use std::fmt;
 use std::fmt::{Debug, Display, Formatter};
 
-#[derive(Copy, Clone, PartialEq, Eq)]
+#[derive(Copy, PartialEq, Eq)]
 pub struct MembershipVector([u8; model::IDENTIFIER_SIZE_BYTES]);
+
+#[allow(useless_deprecated)]
+impl Clone for MembershipVector {
+    #[deprecated(note = "This type is Copy; prefer implicit copying instead of .clone()")]
+    fn clone(&self) -> Self {
+        *self
+    }
+}
 
 /// A struct representing a membership vector with a fixed size of 32 bytes.
 impl MembershipVector {

--- a/src/core/model/search.rs
+++ b/src/core/model/search.rs
@@ -2,7 +2,7 @@ use crate::core::lookup::LookupTableLevel;
 use crate::core::model::direction::Direction;
 use crate::core::Identifier;
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Copy, Clone)]
 pub struct IdSearchReq {
     pub target: Identifier,
     pub level: LookupTableLevel,
@@ -42,7 +42,7 @@ impl IdSearchReq {
 ///
 /// This struct derives the `Debug` trait, enabling it to be formatted using the `{:?}` formatter
 /// for debugging purposes.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Copy, Clone)]
 pub struct IdSearchRes {
     target: Identifier,
     termination_level: LookupTableLevel,

--- a/src/core/testutil/fixtures.rs
+++ b/src/core/testutil/fixtures.rs
@@ -292,8 +292,8 @@ pub fn random_lookup_table(n: usize) -> ArrayLookupTable {
     let lt = ArrayLookupTable::new(&span_fixture());
     let ids = random_identities(2 * n);
     for i in 0..n {
-        lt.update_entry(ids[i].clone(), i, Direction::Left).unwrap();
-        lt.update_entry(ids[i + n].clone(), i, Direction::Right)
+        lt.update_entry(ids[i], i, Direction::Left).unwrap();
+        lt.update_entry(ids[i + n], i, Direction::Right)
             .unwrap();
     }
     lt


### PR DESCRIPTION
Closes #17 

Implements deprecated Clone trait for all fixed-size types whose fields are also fixed-size. This encourages implicit copying over explicit .clone() calls for performance.

Types updated:
  - `ComparisonResult`, `ComparisonContext`, `Identifier`
  - `MembershipVector`, `Direction`, `Address`, `Identity`

  Pattern applied:
 ```rust
#[derive(Copy, Clone)] // Clone removed from derive
  struct FixedSizeType { ... }

  #[allow(useless_deprecated)]
  impl Clone for FixedSizeType {
      #[deprecated(note = "This type is Copy; prefer implicit copying instead of .clone()")]
      fn clone(&self) -> Self { *self }
  }
```