### PR TITLE
make deprecated .clone() usage on fixed-size types a lint failure

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -307,4 +307,8 @@ impl Clone for FixedSizeType {
 
 **Reference Implementation**: See core model types like `Identifier`, `MembershipVector`, `Direction`, `Address`, `Identity` in `src/core/model/`
 
+**Enforcement**: This pattern is enforced by the linter configuration:
+- Makefile: `make lint` runs clippy with `-D deprecated` and `-D warnings`
+- Clippy's `clone_on_copy` rule catches explicit `.clone()` calls on Copy types and fails the build
+
 **Note**: The `#[allow(useless_deprecated)]` attribute is required to bypass Rust's lint that would otherwise prevent this pattern from compiling.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -307,8 +307,10 @@ impl Clone for FixedSizeType {
 
 **Reference Implementation**: See core model types like `Identifier`, `MembershipVector`, `Direction`, `Address`, `Identity` in `src/core/model/`
 
-**Enforcement**: This pattern is enforced by the linter configuration:
-- Makefile: `make lint` runs clippy with `-D deprecated` and `-D warnings`
-- Clippy's `clone_on_copy` rule catches explicit `.clone()` calls on Copy types and fails the build
+**Enforcement**: This pattern is enforced by dual mechanisms in the linter configuration:
+- **`-D deprecated`**: Makes builds fail when deprecated methods (like our deprecated Clone implementations) are used
+- **`-D warnings` (clippy::clone_on_copy)**: Catches explicit `.clone()` calls on Copy types as a fallback
+
+Since Clone is manually implemented with `#[deprecated]` on all Copy types, the `-D deprecated` flag ensures builds fail when `.clone()` is called, forcing developers to use implicit copying instead.
 
 **Note**: The `#[allow(useless_deprecated)]` attribute is required to bypass Rust's lint that would otherwise prevent this pattern from compiling.

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ install-lint:
 .PHONEY lint:
 lint:
 	@echo "Running clippy"
-	@cargo clippy --all-targets --all-features -- -D warnings
+	@cargo clippy --all-targets --all-features -- -D warnings -D deprecated
 
 .PHONY install-rustfmt:
 install-rustfmt:

--- a/src/core/model/identity.rs
+++ b/src/core/model/identity.rs
@@ -51,6 +51,7 @@ mod tests {
     #[test]
     fn test_identity() {
         let id = random_identifier();
+        let _ = id.clone();
         let mem_vec = random_membership_vector();
         let address = Address::new("localhost", "1234");
         let identity = Identity::new(&id, &mem_vec, address);

--- a/src/core/model/identity.rs
+++ b/src/core/model/identity.rs
@@ -51,7 +51,6 @@ mod tests {
     #[test]
     fn test_identity() {
         let id = random_identifier();
-        let _ = id.clone();
         let mem_vec = random_membership_vector();
         let address = Address::new("localhost", "1234");
         let identity = Identity::new(&id, &mem_vec, address);


### PR DESCRIPTION
This PR enforces Clippy's `clone_on_copy` rule catches explicit `.clone()` usage and fails builds via `make lint`.
I also adds pattern guidelines to `CLAUDE.md` for future development.

To the reviewers: I have tested the behaviour manually, and confirm that it works.