### PR TITLE
refactor: rename event variants to SearchByIdRequest/Response

### DIFF
--- a/src/network/mod.rs
+++ b/src/network/mod.rs
@@ -10,8 +10,8 @@ pub use processor::MessageProcessor;
 #[derive(Debug, Clone)]
 pub enum Event {
     TestMessage(String), // A payload for testing purposes, it is a simple string event, and is not used in production.
-    IdSearchRequest(IdSearchReq), // A payload representing an identifier search request.
-    IdSearchResponse(IdSearchRes) // A payload representing an identifier search response.
+    SearchByIdRequest(IdSearchReq), // A payload representing an identifier search request.
+    SearchByIdResponse(IdSearchRes) // A payload representing an identifier search response.
 }
 
 /// Core event processing logic that implementations must provide.

--- a/src/node/base_node.rs
+++ b/src/node/base_node.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 use crate::core::{IdSearchReq, IdSearchRes, Identifier, IrrevocableContext, MembershipVector};
-use crate::network::Event::{IdSearchRequest, IdSearchResponse};
+use crate::network::Event::{SearchByIdRequest, SearchByIdResponse};
 #[cfg(test)] // TODO: Remove once BaseNode is used in production code.
 use crate::network::MessageProcessor;
 use crate::network::{Event, EventProcessorCore, Network};
@@ -100,7 +100,7 @@ impl BaseNode {
             let mut request_id_map = self.request_id_map.lock().expect("mutex was poisoned by a previous panic");
             request_id_map.insert(req.req_id(), tx);
         }
-        let relay_request = IdSearchRequest(IdSearchReq::new(
+        let relay_request = SearchByIdRequest(IdSearchReq::new(
             req.req_id(),
             *self.core.id(),
             *req.target(),
@@ -129,7 +129,7 @@ impl EventProcessorCore for BaseNode {
         let _enter = self.span.enter();
 
         match event {
-            IdSearchRequest(req) => {
+            SearchByIdRequest(req) => {
                 let span = tracing::trace_span!(
                     "search_by_id_request",
                     origin = ?origin_id,
@@ -154,7 +154,7 @@ impl EventProcessorCore for BaseNode {
 
                 if res.result() == self.core.id() {
                     self.net
-                        .send_event(*req.origin(), IdSearchResponse(res))
+                        .send_event(*req.origin(), SearchByIdResponse(res))
                         .map_err(|e| {
                             anyhow!("failed to send response event for search by id: {}", e)
                         })?;
@@ -162,7 +162,7 @@ impl EventProcessorCore for BaseNode {
                     return Ok(());
                 }
 
-                let relay_request = IdSearchRequest(IdSearchReq::new(
+                let relay_request = SearchByIdRequest(IdSearchReq::new(
                     req.req_id(),
                     *req.origin(),
                     *req.target(),
@@ -180,7 +180,7 @@ impl EventProcessorCore for BaseNode {
                 tracing::info!("relayed search by id request to the next node");
                 Ok(())
             }
-            IdSearchResponse(res) => {
+            SearchByIdResponse(res) => {
                 let span = tracing::trace_span!(
                     "search_by_id_response",
                     origin = ?origin_id,

--- a/src/node/search_by_id_test.rs
+++ b/src/node/search_by_id_test.rs
@@ -35,7 +35,7 @@ fn test_search_by_id_networking_integration_relay() {
 
     let node_id = random_identifier();
     let search_request = IdSearchReq::new(RequestId::random(), node_id, target, 0, Direction::Left);
-    let request_event = Event::IdSearchRequest(search_request);
+    let request_event = Event::SearchByIdRequest(search_request);
 
     let (expected_lvl, expected_identity) = lt
         .left_neighbors()
@@ -53,7 +53,7 @@ fn test_search_by_id_networking_integration_relay() {
             .each_call(matching!(_))
             .answers_arc(Arc::new(
                 move |_, id: Identifier, event: Event| match event {
-                    Event::IdSearchRequest(req) => {
+                    Event::SearchByIdRequest(req) => {
                         assert_eq!(req.level(), expected_lvl);
                         assert_eq!(id, *expected_identity.id());
                         Ok(())
@@ -92,7 +92,7 @@ fn test_search_by_id_networking_integration_target_is_this_node() {
     let node_id = random_identifier();
 
     let search_request = IdSearchReq::new(RequestId::random(), origin_id, node_id, 0, Direction::Left);
-    let request_event = Event::IdSearchRequest(search_request);
+    let request_event = Event::SearchByIdRequest(search_request);
 
     let mock_net = Unimock::new((
         NetworkMock::register_processor
@@ -102,7 +102,7 @@ fn test_search_by_id_networking_integration_target_is_this_node() {
             .each_call(matching!(_))
             .answers_arc(Arc::new(
                 move |_, id: Identifier, event: Event| match event {
-                    Event::IdSearchResponse(res) => {
+                    Event::SearchByIdResponse(res) => {
                         assert_eq!(
                             id, origin_id,
                             "expected result to be to the originator's identifier"


### PR DESCRIPTION
Renames `IdSearchRequest` → `SearchByIdRequest` and `IdSearchResponse` → `SearchByIdResponse` in the `Event` enum and all call sites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)