### PR TITLE
ci: pin @claude action to claude-opus-4-8

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -40,8 +40,9 @@ jobs:
           additional_permissions: |
             actions: read
           
-          # Optional: Specify model (defaults to Claude Sonnet 4, uncomment for Claude Opus 4.1)
-          # model: "claude-opus-4-1-20250805"
+          # Pin the model explicitly: the action's built-in default model has been
+          # retired and now returns a 404 not_found_error.
+          model: "claude-opus-4-8"
           
           # Optional: Customize the trigger phrase (default: @claude)
           # trigger_phrase: "/claude"


### PR DESCRIPTION
## Problem

The `@claude` GitHub Action job is failing with:

```
API Error: 404 {"type":"error","error":{"type":"not_found_error","message":"model: claude-sonnet-4-20250514"}}
```

The workflow doesn't set a `model`, so it falls back to the action's built-in default (`claude-sonnet-4-20250514`), which has been **retired** and now returns `404 not_found_error`.

## Why it must land on `main`

`issue_comment`-triggered workflows always execute the workflow file from the **default branch**, not the PR branch. A fix on a feature branch never takes effect for the `@claude` trigger — so this dedicated PR targets `main`.

## Fix

Pin an explicit, current model:

```yaml
model: "claude-opus-4-8"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)