### PR TITLE
[feat][node] Add RepairSchedule trait with tokio and manual impls

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,6 @@ unimock = "0.6"
 parking_lot = "0.12"
 tokio = { version = "1.0", features = ["sync", "time", "macros", "rt", "rt-multi-thread"] }
 tokio-util = "0.7"
+
+[dev-dependencies]
+tokio = { version = "1.0", features = ["test-util"] }

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -2,6 +2,9 @@ mod base_node;
 pub(crate) mod core;
 #[cfg(test)]
 mod core_test;
+mod repair_schedule;
+#[cfg(test)]
+mod repair_schedule_test;
 #[cfg(test)]
 mod search_by_id_test;
 #[cfg(test)]

--- a/src/node/repair_schedule.rs
+++ b/src/node/repair_schedule.rs
@@ -8,7 +8,7 @@ use tokio::time::Interval;
 
 /// RepairSchedule abstracts "wait for the next backpointer-repair tick" so the repair task
 /// never calls `tokio::time::sleep`/`interval` directly. [`TokioRepairSchedule`] is the
-/// production implementation; [`ManualRepairSchedule`] is a test double a test drives
+/// production implementation; [`ManualRepairSchedule`] is a test double that a test drives
 /// explicitly, one tick at a time, with zero wall-clock waiting.
 // TODO: remove once RepairSchedule is wired into the repair task.
 #[allow(dead_code)]

--- a/src/node/repair_schedule.rs
+++ b/src/node/repair_schedule.rs
@@ -1,0 +1,79 @@
+use std::future::Future;
+use std::pin::Pin;
+use std::time::Duration;
+use tokio::sync::Mutex;
+#[cfg(test)]
+use tokio::sync::Notify;
+use tokio::time::Interval;
+
+/// RepairSchedule abstracts "wait for the next backpointer-repair tick" so the repair task
+/// never calls `tokio::time::sleep`/`interval` directly. [`TokioRepairSchedule`] is the
+/// production implementation; [`ManualRepairSchedule`] is a test double a test drives
+/// explicitly, one tick at a time, with zero wall-clock waiting.
+// TODO: remove once RepairSchedule is wired into the repair task.
+#[allow(dead_code)]
+pub(crate) trait RepairSchedule: Send + Sync {
+    /// Waits for the next repair tick.
+    fn tick(&self) -> Pin<Box<dyn Future<Output = ()> + Send + '_>>;
+}
+
+/// Production `RepairSchedule`, backed by a real `tokio::time::Interval`.
+// TODO: remove once RepairSchedule is wired into the repair task.
+#[allow(dead_code)]
+pub(crate) struct TokioRepairSchedule {
+    interval: Mutex<Interval>,
+}
+
+impl TokioRepairSchedule {
+    /// Creates a schedule that ticks every `period`.
+    ///
+    /// # Args
+    ///
+    /// * `period` - the duration between repair ticks.
+    ///
+    /// Must be called from within a running Tokio runtime, per
+    /// `tokio::time::interval`'s own precondition.
+    #[allow(dead_code)] // TODO: remove once RepairSchedule is wired into the repair task.
+    pub(crate) fn new(period: Duration) -> Self {
+        TokioRepairSchedule {
+            interval: Mutex::new(tokio::time::interval(period)),
+        }
+    }
+}
+
+impl RepairSchedule for TokioRepairSchedule {
+    fn tick(&self) -> Pin<Box<dyn Future<Output = ()> + Send + '_>> {
+        Box::pin(async move {
+            self.interval.lock().await.tick().await;
+        })
+    }
+}
+
+/// Test `RepairSchedule`, driven by an explicit, manually-fired gate:
+/// [`ManualRepairSchedule::fire`] completes exactly one pending or future
+/// [`RepairSchedule::tick`] call.
+#[cfg(test)]
+pub(crate) struct ManualRepairSchedule {
+    notify: Notify,
+}
+
+#[cfg(test)]
+impl ManualRepairSchedule {
+    pub(crate) fn new() -> Self {
+        ManualRepairSchedule {
+            notify: Notify::new(),
+        }
+    }
+
+    /// Fires exactly one repair tick, completing one pending or future `tick()` call.
+    pub(crate) fn fire(&self) {
+        self.notify.notify_one();
+    }
+}
+
+#[cfg(test)]
+impl RepairSchedule for ManualRepairSchedule {
+    fn tick(&self) -> Pin<Box<dyn Future<Output = ()> + Send + '_>> {
+        Box::pin(self.notify.notified())
+    }
+}

--- a/src/node/repair_schedule_test.rs
+++ b/src/node/repair_schedule_test.rs
@@ -1,0 +1,63 @@
+use crate::node::repair_schedule::{ManualRepairSchedule, RepairSchedule, TokioRepairSchedule};
+use std::sync::Arc;
+use std::time::Duration;
+
+/// Verifies `fire` completes a `tick` call that is already pending.
+#[tokio::test]
+async fn test_manual_repair_schedule_fire_completes_pending_tick() {
+    let schedule = Arc::new(ManualRepairSchedule::new());
+    let waiter = tokio::spawn({
+        let schedule = schedule.clone();
+        async move { schedule.tick().await }
+    });
+
+    // give the spawned task a chance to start polling `tick()` before firing.
+    tokio::task::yield_now().await;
+    schedule.fire();
+
+    tokio::time::timeout(Duration::from_secs(2), waiter)
+        .await
+        .expect("tick did not complete before the timeout")
+        .expect("spawned task panicked");
+}
+
+/// Verifies a `fire` issued before `tick` is called is not lost: the next `tick` call
+/// completes immediately instead of waiting for a subsequent `fire`.
+#[tokio::test]
+async fn test_manual_repair_schedule_fire_before_tick_is_not_lost() {
+    let schedule = ManualRepairSchedule::new();
+    schedule.fire();
+
+    tokio::time::timeout(Duration::from_secs(2), schedule.tick())
+        .await
+        .expect("tick did not complete before the timeout");
+}
+
+/// Verifies a single `fire` unblocks exactly one `tick` call: a second, independent
+/// `tick` call still waits for its own `fire`.
+#[tokio::test(start_paused = true)]
+async fn test_manual_repair_schedule_single_fire_grants_exactly_one_tick() {
+    let schedule = ManualRepairSchedule::new();
+    schedule.fire();
+
+    tokio::time::timeout(Duration::from_secs(2), schedule.tick())
+        .await
+        .expect("first tick did not complete before the timeout");
+
+    let second_tick = tokio::time::timeout(Duration::from_millis(50), schedule.tick()).await;
+    assert!(
+        second_tick.is_err(),
+        "second tick completed without its own fire"
+    );
+}
+
+/// Verifies `TokioRepairSchedule::tick` actually resolves once its period elapses,
+/// confirming the trait is correctly wired to a real `tokio::time::Interval`.
+#[tokio::test(start_paused = true)]
+async fn test_tokio_repair_schedule_ticks_after_period_elapses() {
+    let schedule = TokioRepairSchedule::new(Duration::from_millis(100));
+
+    tokio::time::timeout(Duration::from_secs(2), schedule.tick())
+        .await
+        .expect("tick did not complete before the timeout");
+}

--- a/src/node/repair_schedule_test.rs
+++ b/src/node/repair_schedule_test.rs
@@ -57,7 +57,17 @@ async fn test_manual_repair_schedule_single_fire_grants_exactly_one_tick() {
 async fn test_tokio_repair_schedule_ticks_after_period_elapses() {
     let schedule = TokioRepairSchedule::new(Duration::from_millis(100));
 
+    // `tokio::time::interval`'s own first tick resolves immediately; consume it so the
+    // assertions below observe a tick that actually waited out the period.
+    schedule.tick().await;
+
+    let premature = tokio::time::timeout(Duration::from_millis(50), schedule.tick()).await;
+    assert!(
+        premature.is_err(),
+        "tick completed before its period elapsed"
+    );
+
     tokio::time::timeout(Duration::from_secs(2), schedule.tick())
         .await
-        .expect("tick did not complete before the timeout");
+        .expect("tick did not complete after its period elapsed");
 }


### PR DESCRIPTION
Adds a `RepairSchedule` trait abstracting "wait for the next repair tick," with `TokioRepairSchedule` (production, real interval) and `ManualRepairSchedule` (test-only, fired explicitly).